### PR TITLE
docs(skills): post-merge follow-ups for the focus-group framework

### DIFF
--- a/docs/generated/playbook.md
+++ b/docs/generated/playbook.md
@@ -1,41 +1,73 @@
 # ACE Playbook — CRISPR-Connect Process
 
-Generated: 2026-04-01
+Generated: 2026-04-08
 
 ## Overview
 
-ACE (AI Connect Engine) is a Claude Code plugin that orchestrates the full CRISPR-Connect lifecycle for Connect opportunities. It manages everything from initial idea through app building, platform setup, LLO (Local Lead Organization) management, and closeout. ACE is built around 5 agents, 17 skills, and integrations with Connect, CommCare, OCS, and Nova.
+ACE (AI Connect Engine) is a Claude Code plugin that orchestrates the full CRISPR-Connect lifecycle for Connect opportunities. It manages everything from initial idea through app building, platform setup, LLO (Local Lead Organization) management, and closeout. ACE is built around 5 agents, 19 skills, and integrations with Connect, CommCare, OCS, and Nova.
 
 ACE supports two execution modes:
 
 - **Auto mode:** Runs all phases sequentially without human gates. Emails the CRISPR Admin group (Neal, Jon, Matt, Sarvesh, Cal) at each step completion and on failures. Gates are logged but not enforced.
-- **Review mode:** Runs all phases sequentially but pauses at gate steps. Uses interactive prompts to present results and get approval before proceeding. Gate steps are: after IDD creation, after app deployment, and after LLO invite list generation.
+- **Review mode:** Runs all phases sequentially but pauses at gate steps. Uses interactive prompts to present results and get approval before proceeding. Gate steps are: after IDD creation, after app deployment, after LLO invite list generation, and after opportunity go-live readiness.
 
-Opportunity state lives in Google Drive under `ACE/<opp-name>/`, tracked in a `state.yaml` file that records the current phase, step, mode, timestamps, gate approvals, and errors.
+Opportunity state lives in Google Drive under `ACE/<opp-name>/`, tracked in a `state.yaml` file that records the current phase, step, mode, archetype, timestamps, gate approvals, and errors.
+
+## Skill Framework
+
+Every ACE skill is a SKILL.md file under `skills/` that follows the contract documented at `skills/README.md`. Skills are stateless prompt definitions that Claude executes — they read from and write to the opportunity's GDrive folder and call MCP tools for external system access.
+
+Two framework primitives shape how skills branch on the IDD:
+
+### Delivery archetypes
+
+Every IDD declares a delivery `Archetype:` in its frontmatter. The archetype determines how downstream skills behave:
+
+- **`atomic-visit`** — one FLW visit produces one structured delivery (photo + GPS + form). Verification is automated. Examples: turmeric market survey, household-level data collection. **Default if unspecified.**
+- **`focus-group`** — one FLW-facilitated group session produces qualitative content (audio + per-domain summaries + attendance). Verification mixes automated session-level checks with AI-assisted content evaluation. Example: vaccine-hesitancy Stage 1 focus groups.
+- **`multi-stage`** — combines two or more archetypes across sequenced stages, each with its own gate. Example: full vaccine-hesitancy IDD (Stage 1 = focus-group, Stage 2 = atomic household visits).
+
+7 of the 19 skills branch on archetype: `idea-to-idd`, `idd-to-learn-app`, `idd-to-deliver-app`, `app-test`, `connect-opp-setup`, `flw-data-review`, `cycle-grade`. Each has a `## Archetypes` section in its SKILL.md describing the per-archetype behavior. Adding a new archetype is an additive change to those 7 skills plus the IDD template — no new skill files.
+
+### Evidence Model (Layer A / B / C)
+
+Every IDD declares an `## Evidence Model` section using a shared three-layer vocabulary:
+
+- **Layer A — Delivery proof** (the thing happened). Automated, hard gates. Drives verification rules in `connect-opp-setup` and capture-path tests in `app-test`.
+- **Layer B — Content proof** (it was done properly). AI-assisted or structured human review. Drives content-quality tests in `app-test` and per-delivery review in `flw-data-review`.
+- **Layer C — Cross-delivery quality** (the data is useful). AI synthesis. Drives cross-delivery review in `flw-data-review` and Intervention Effectiveness / Research Quality grading in `cycle-grade`.
+
+4 downstream skills (`connect-opp-setup`, `app-test`, `flw-data-review`, `cycle-grade`) read from the IDD's Evidence Model section as their primary input rather than re-deriving verification from the IDD body. They error out if the section is missing — that signals `idea-to-idd` short-circuited the stress-test rubric.
+
+### Stress-test rubric (in `idea-to-idd`)
+
+`idea-to-idd` self-evaluates every drafted IDD against a 5-question rubric — **executability, verifiability, measurability, stage-gate clarity, resource realism** — and blocks IDD approval at ≥2 non-pass. The rubric includes calibrated grading anchors from the example IDDs at `docs/examples/idd-vaccine-hesitancy.md` (canonical fail) and `docs/examples/idd-turmeric-market-survey.md` (canonical near-pass).
 
 ## Process Flow
 
-| Step | Name | Skill | Phase | LLM-as-Judge | Gate | Recurring |
-|------|------|-------|-------|:---:|:---:|:---:|
-| 1 | Idea to IDD | `idea-to-idd` | App Building | Yes | Yes | No |
-| 2 | IDD to Learn App | `idd-to-learn-app` | App Building | Yes | No | No |
-| 3 | IDD to Deliver App | `idd-to-deliver-app` | App Building | Yes | No | No |
-| 4 | App Deploy | `app-deploy` | App Building | No | Yes | No |
-| 5 | App Test | `app-test` | App Building | Yes | No | No |
-| 6 | Training Materials | `training-materials` | App Building | Yes | No | No |
-| 7 | Connect Program Setup | `connect-program-setup` | Connect Setup | No | No | No |
-| 8 | Connect Opportunity Setup | `connect-opp-setup` | Connect Setup | No | No | No |
-| 9 | LLO Invite | `llo-invite` | Connect Setup | No | Yes | No |
-| 10 | LLO Onboarding | `llo-onboarding` | LLO Management | No | No | No |
-| 11 | OCS Agent Setup | `ocs-agent-setup` | LLO Management | Yes | No | No |
-| 12 | Timeline Monitor | `timeline-monitor` | LLO Management | Yes | No | Yes |
-| 13 | FLW Data Review | `flw-data-review` | LLO Management | Yes | No | Yes |
-| 14 | Opportunity Closeout | `opp-closeout` | Closeout | No | No | No |
-| 15 | LLO Feedback | `llo-feedback` | Closeout | No | No | No |
-| 16 | Learnings Summary | `learnings-summary` | Closeout | No | No | No |
-| 17 | Cycle Grade | `cycle-grade` | Closeout | Yes | No | No |
+| Step | Name | Skill | Phase | LLM-as-Judge | Gate | Recurring | Archetype-aware |
+|------|------|-------|-------|:---:|:---:|:---:|:---:|
+| 1 | Idea to IDD | `idea-to-idd` | App Building | Yes | Yes | No | Yes |
+| 2 | IDD to Learn App | `idd-to-learn-app` | App Building | Yes | No | No | Yes |
+| 3 | IDD to Deliver App | `idd-to-deliver-app` | App Building | Yes | No | No | Yes |
+| 4 | App Deploy | `app-deploy` | App Building | No | Yes | No | No |
+| 5 | App Test | `app-test` | App Building | Yes | No | No | Yes |
+| 6 | Training Materials | `training-materials` | App Building | Yes | No | No | No |
+| 7 | Connect Program Setup | `connect-program-setup` | Connect Setup | No | No | No | No |
+| 8 | Connect Opportunity Setup | `connect-opp-setup` | Connect Setup | No | No | No | Yes |
+| 9 | LLO Invite | `llo-invite` | Connect Setup | No | Yes | No | No |
+| 10 | LLO Onboarding | `llo-onboarding` | LLO Management | No | No | No | No |
+| 11 | LLO User Acceptance Testing | `llo-uat` | LLO Management | No | No | No | No |
+| 12 | LLO Launch (go-live) | `llo-launch` | LLO Management | No | Yes | No | No |
+| 13 | OCS Agent Setup | `ocs-agent-setup` | LLO Management | Yes | No | No | No |
+| 14 | Timeline Monitor | `timeline-monitor` | LLO Management | Yes | No | Yes | No |
+| 15 | FLW Data Review | `flw-data-review` | LLO Management | Yes | No | Yes | Yes |
+| 16 | Opportunity Closeout | `opp-closeout` | Closeout | No | No | No | No |
+| 17 | LLO Feedback | `llo-feedback` | Closeout | No | No | No | No |
+| 18 | Learnings Summary | `learnings-summary` | Closeout | No | No | No | No |
+| 19 | Cycle Grade | `cycle-grade` | Closeout | Yes | No | No | Yes |
 
-Notes: Steps 2-3 run in parallel. Steps 5-6 run in parallel. Steps 12-13 run weekly on a recurring schedule during the active opportunity.
+Notes: Steps 2–3 run in parallel. Steps 5–6 run in parallel. Steps 14–15 run weekly on a recurring schedule during the active opportunity.
 
 ## Phase 1: App Building
 
@@ -47,101 +79,109 @@ Orchestrates the app building phase of CRISPR-Connect: idea iteration into an ID
 
 #### idea-to-idd
 
-Takes an initial idea and iterates on it to produce a complete Intervention Design Document (IDD). The IDD specifies the intervention, target FLWs, visit structure, app requirements for both Learn and Deliver apps, success metrics, and preferred LLOs. The skill reads the idea from GDrive, researches and expands it into a structured IDD with sections covering problem statement through timeline, then self-evaluates for completeness and feasibility using LLM-as-Judge. In review mode this is a gate step requiring human approval before apps are generated. Uses Google Drive MCP tools.
+Iterate on an idea to produce a well-specified Intervention Design Doc (IDD) for a Connect application. Defines the intervention, target FLWs, visit structure, and preferred LLOs. **Archetype-aware**: branches on `atomic-visit` / `focus-group` / `multi-stage` to add the correct sections to the IDD draft (recruitment plan, facilitation protocol, question guide, output specification for focus groups; standard form-walkthrough sections for atomic visits). **Self-evaluates** with the 5-question stress-test rubric (executability, verifiability, measurability, stage-gate clarity, resource realism) and blocks approval at ≥2 non-pass. Includes calibrated grading anchors from `docs/examples/idd-vaccine-hesitancy.md` and `docs/examples/idd-turmeric-market-survey.md`. Stress-test results emitted as a `## Stress Test Results` appendix on every IDD. In review mode this is a gate step requiring human approval before apps are generated. Uses Google Drive MCP tools.
 
 #### idd-to-learn-app
 
-Generates the Learn (data collection) app from the approved IDD by passing the Learn app spec to Nova. The skill extracts data collection requirements, visit structure, form design, and case management needs from the IDD, then provides these to Nova and captures all configuration decisions. It self-evaluates whether the generated app matches the IDD spec. Currently falls back to generating a structured app brief for manual Nova interaction until the Nova API integration is built. Uses Google Drive and Nova MCP tools.
+Pass an IDD to Nova to generate the Learn app. Answer Nova's configuration questions and output the app JSON/CCZ and a summary of decisions made. **Archetype-aware**: for `atomic-visit` IDDs, generates a standard form-walkthrough Learn app brief; for `focus-group` IDDs, generates a *facilitation training* brief (facilitation basics, probing techniques, neutral framing, group dynamics, question-guide walkthrough, session-form walkthrough, consent and ethics, logistics) — explicitly *not* a form walkthrough. For `multi-stage` IDDs, generates per-stage apps. Currently falls back to generating a structured app brief for manual Nova interaction until the Nova API integration is built. Uses Google Drive and Nova MCP tools.
 
 #### idd-to-deliver-app
 
-Generates the Deliver (service delivery) app from the approved IDD by passing the Deliver app spec to Nova. The skill extracts service delivery workflows, verification criteria, payment triggers, and case management needs from the IDD. It follows the same pattern as `idd-to-learn-app` -- self-evaluates the generated app against the IDD spec and falls back to a manual brief workflow until Nova integration is available. Runs in parallel with `idd-to-learn-app`. Uses Google Drive and Nova MCP tools.
+Pass an IDD to Nova to generate the Deliver app. **Archetype-aware**: for `atomic-visit` IDDs, generates a per-beneficiary form with case lifecycle per beneficiary; for `focus-group` IDDs, generates a session-documentation form with pre-session, per-question-domain (one section per IDD domain), and post-session blocks, with case management at the **segment level** (not per participant). The Nova prompt is explicit about the difference. Runs in parallel with `idd-to-learn-app`. Currently falls back to a manual brief workflow until Nova integration is available. Uses Google Drive and Nova MCP tools.
 
 #### app-deploy
 
-Uploads the generated Learn and Deliver app packages to the CRISPR-Connect domain on CommCare HQ, then triggers the build and publish process. The skill reads app files from GDrive and produces a deployment summary with app IDs, build status, and published URLs. This is a gate step in review mode -- apps must be verified before proceeding. Currently requires manual upload via the HQ UI because the CommCare app upload/build/publish APIs are not yet exposed via MCP. Uses Google Drive and CommCare MCP tools.
+Upload the generated Learn and Deliver app packages to the CRISPR-Connect domain on CommCare HQ, then trigger the build and publish process. Reads app files from GDrive and produces a deployment summary with app IDs, build status, and published URLs. This is a gate step in review mode — apps must be verified before proceeding. Currently requires manual upload via the HQ UI because the CommCare app upload/build/publish APIs are not yet exposed via MCP. Uses Google Drive and CommCare MCP tools.
 
 #### app-test
 
-Creates a comprehensive test plan and executes it against the deployed Learn and Deliver apps. The skill generates test cases covering form completion flows, case management, skip logic, validation rules, edge cases, and cross-form data flow. It uses the CommCare MCP to inspect app structure and form questions, documents each test case with pass/fail results, and self-evaluates test coverage. Outputs a test plan, results, and bug list with severity and repro steps. Uses Google Drive and CommCare MCP tools.
+Create and execute an automated test plan for the Learn and Deliver apps; identify bugs and issues before LLO deployment. **Archetype-aware** and **Evidence-Model-consuming**: reads the IDD's `archetype:` and `## Evidence Model` section in step 3, then uses Layer A entries as the checklist of what must be capturable end-to-end (every Layer A artifact gets a passing capture test) and Layer B entries to determine which content fields need length and quality validation tests. For `atomic-visit`, covers form completion, case management, skip logic, validation, edge cases, cross-form data flow. For `focus-group`, covers per-domain section coverage, file-upload paths (audio, attendance photo), consent gating, and segment-level case lifecycle — explicitly *not* per-beneficiary atomicity. Errors out if the IDD has no Evidence Model section. Uses Google Drive and CommCare MCP tools.
 
 #### training-materials
 
-Generates training materials for LLOs and FLWs from the IDD and app summaries. Produces four documents: an LLO Manager Guide (opportunity overview, timeline, expectations), an FLW Training Guide (step-by-step app instructions), a Quick Reference Card (one-page workflow summary), and an FAQ (anticipated questions). The skill self-evaluates whether instructions are clear enough for someone with no prior context and whether all key workflows are covered. Uses Google Drive MCP tools.
+Generate training materials for LLOs and FLWs from app summaries and template collateral. Output guides, quick-reference cards, and onboarding docs. The skill produces an LLO Manager Guide, an FLW Training Guide, a Quick Reference Card, and an FAQ, and self-evaluates whether instructions are clear enough for someone with no prior context. Uses Google Drive MCP tools.
 
 ## Phase 2: Connect Setup
 
 ### Agent: connect-setup
 
-Sets up the Connect platform for a CRISPR-Connect opportunity: program creation or reuse, opportunity configuration with verification rules and delivery/payment units, and LLO invitations. Steps are sequential because each depends on the previous one's output (Program ID, then Opportunity ID).
+Orchestrates Connect platform setup for a CRISPR-Connect opportunity: program creation, opportunity configuration, and LLO invitations. Steps are sequential because each depends on the previous one's output (Program ID, then Opportunity ID).
 
 ### Skills
 
 #### connect-program-setup
 
-Creates or selects a Connect program for the opportunity. The skill reads the IDD, checks for existing programs that match the opportunity's domain, and decides whether to reuse an existing program or create a new one. Currently requires manual program creation via the Connect UI because the `create_program` API is not yet built (tracked as CCC-301). The skill generates the recommended program configuration and asks the user to create it. Uses Google Drive and Connect MCP tools.
+Create or configure a Program in Connect for the CRISPR-Connect opportunity. Checks if an existing program fits before creating a new one. Currently requires manual program creation via the Connect UI because the `create_program` API is not yet built (tracked as CCC-301). Generates the recommended program configuration and asks the user to create it. Uses Google Drive and Connect MCP tools.
 
 #### connect-opp-setup
 
-Creates and fully configures a Connect opportunity including verification rules (mapped from IDD success metrics and Deliver app structure), delivery units (based on intervention design), and payment units (based on delivery units and budget). The skill reads the IDD, program details, and deployment summary to generate a complete configuration spec. Currently requires manual opportunity creation via the Connect UI because the `create_opportunity` and related configuration APIs are not yet built (CCC-301). Uses Google Drive and Connect MCP tools.
+Create and configure an Opportunity in Connect — including verification rules, delivery units, payment units, and all other configuration needed for the opp. **Archetype-aware** and **Evidence-Model-consuming**: reads the IDD's `archetype:` and `## Evidence Model` section in step 2, then uses **Layer A** entries as the spec for verification rules (each Layer A row → one rule) and treats Layer B/C entries as soft flags (logged for human review, not blocking). For `atomic-visit`, delivery unit = one verified beneficiary visit; for `focus-group`, delivery unit = one **completed group session** (not per participant) and payment unit count is set from the IDD's planned session count. Errors out if the IDD has no Evidence Model section. Currently requires manual opportunity creation via the Connect UI because the `create_opportunity` and related configuration APIs are not yet built (CCC-301). Uses Google Drive and Connect MCP tools.
 
 #### llo-invite
 
-Identifies and invites LLOs to participate in the opportunity. The skill reads the IDD's LLO preference section, searches the LLO Directory for matching organizations, and prepares an invite list with rationale for each selection. This is a gate step in review mode -- the invite list must be approved before invitations are sent. Currently requires manual invite sending via the Connect UI because the `send_llo_invite` API is not yet built. Uses Google Drive and Connect MCP tools.
+Look up LLO contacts from the LLO Directory and invite them to the Connect opportunity. Reads the IDD's LLO preference section, searches the LLO Directory for matching organizations, and prepares an invite list with rationale for each selection. This is a gate step in review mode — the invite list must be approved before invitations are sent. Currently requires manual invite sending via the Connect UI because the `send_llo_invite` API is not yet built. Uses Google Drive and Connect MCP tools.
 
 ## Phase 3: LLO Management
 
 ### Agent: llo-manager
 
-Manages LLO relationships during an active opportunity: onboarding new LLOs, configuring the OCS support agent, and running ongoing monitoring. This phase includes two recurring skills (timeline-monitor and flw-data-review) that execute on a weekly schedule throughout the active opportunity period. The phase is "complete" when the opportunity reaches its end date.
+Orchestrates LLO management during an active opportunity: onboarding, UAT, go-live, OCS agent setup, timeline monitoring, and FLW data review. This phase includes two recurring skills (`timeline-monitor` and `flw-data-review`) that execute on a weekly schedule throughout the active opportunity period. The phase is "complete" when the opportunity reaches its end date.
 
 ### Skills
 
 #### llo-onboarding
 
-Sends onboarding communications to LLOs who accepted the opportunity invitation. For each LLO, the skill composes a welcome email from Ace-AI@Dimagi.com with opportunity overview, links to training materials, step-by-step getting-started instructions, timeline, and support contact information. All emails CC the CRISPR Admin group. Currently generates email drafts for the user to send manually until email sending is automated. Uses Google Drive MCP tools.
+Send onboarding emails to invited LLOs with training materials, app instructions, and next steps. Uses Ace-AI@Dimagi.com as sender, with all emails CC'd to the CRISPR Admin group. Currently generates email drafts for the user to send manually until email sending is automated. Uses Google Drive MCP tools.
+
+#### llo-uat
+
+Coordinate User Acceptance Testing with onboarded LLOs. Send UAT instructions, monitor for feedback, and compile results with LLO sign-off status. Reads OCS transcripts during the UAT window for surfaced issues. Uses Google Drive and OCS MCP tools.
+
+#### llo-launch
+
+Activate the opportunity for live use. Verify UAT sign-offs, activate the opportunity in Connect, confirm apps are published, and notify LLOs of go-live. This is a gate step in review mode — launch readiness must be verified before activating. Uses Google Drive, Connect, and CommCare MCP tools.
 
 #### ocs-agent-setup
 
-Creates and configures an OCS (Operational Conversational System) agent to handle LLO questions for the opportunity. The skill composes a context document from the IDD, training materials, app summaries, and opportunity details, then creates an OCS agent with that context, email routing to Ace-AI@Dimagi.com, and admin-group CC rules. Self-evaluates whether the context is comprehensive enough for typical LLO questions. Currently requires manual OCS agent creation because the OCS MCP server is not yet built. Uses Google Drive and OCS MCP tools.
+Configure an OCS agent for this opportunity. Inject the IDD, training materials, and opportunity context so OCS can answer LLO questions. Composes a context document, creates the agent, sets email routing to Ace-AI@Dimagi.com, and configures admin-group CC rules. Self-evaluates whether the context is comprehensive enough for typical LLO questions. Currently requires manual OCS agent creation because the OCS MCP server is not yet built. Uses Google Drive and OCS MCP tools.
 
 #### timeline-monitor
 
-Runs periodically (weekly) during the active opportunity to check whether LLOs are hitting expected milestones on schedule. The skill reads timeline data from the IDD, checks FLW activity via CommCare submission data and Connect opportunity status, and drafts prompting emails to LLOs who are behind schedule. Self-evaluates assessment accuracy and recommendation quality. Reports are written to GDrive and the admin group is notified. Uses Google Drive, Connect, and CommCare/scout-data MCP tools.
+Monitor whether LLOs are hitting expected milestones on schedule; send prompting emails if behind. Runs recurring during the active opportunity (typically weekly). Reads timeline data from the IDD, checks FLW activity via CommCare submission data and Connect opportunity status, and drafts prompting emails to LLOs who are behind schedule. Reports are written to GDrive and the admin group is notified. Uses Google Drive, Connect, and CommCare/scout-data MCP tools.
 
 #### flw-data-review
 
-Runs periodically (weekly) during the active opportunity to analyze FLW submission data for quality issues. The skill queries scout-data for submission rates, completion rates, dropout patterns, data quality issues, and case management compliance, then compares against the IDD's expected metrics. Self-evaluates whether identified patterns are real signals and whether recommendations are actionable. Generates specific improvement recommendations for the team to relay to LLOs. Uses Google Drive, CommCare/scout-data, and Connect MCP tools.
+Analyze FLW submission data to identify quality issues, trends, and improvement opportunities. Generate recommendations for the team. Runs recurring during active opp. **Archetype-aware** and **Evidence-Model-consuming**: reads the IDD's `archetype:` and `## Evidence Model` section in step 1; Layer B drives per-delivery evaluation, Layer C drives cross-delivery synthesis. For `atomic-visit`, performs quantitative review (submission rates, completion rates, outlier detection, cap compliance, per-FLW outliers, cross-FLW clustering). For `focus-group`, performs qualitative synthesis (per-session quality, cross-session theme synthesis by segment, saturation check, quote bank, facilitator coaching signals) — explicitly *not* quantitative checks. Uses Google Drive, CommCare/scout-data, and Connect MCP tools.
 
 ## Phase 4: Closeout
 
 ### Agent: closeout
 
-Handles the closeout of a completed CRISPR-Connect opportunity. Triggered when the opportunity reaches its end date. Processes invoices and payment, collects LLO feedback, synthesizes learnings across the entire cycle, and produces a final cycle grade. The learnings summary can trigger another CRISPR-Connect cycle by drafting a new IDD.
+Orchestrates opportunity closeout: invoice processing, LLO feedback collection, learnings summary, and overall cycle grading. Triggered when the opportunity reaches its end date. The learnings summary can trigger another CRISPR-Connect cycle by drafting a new IDD.
 
 ### Skills
 
 #### opp-closeout
 
-Processes the financial closeout of a completed opportunity. The skill pulls invoices from Connect based on verified deliveries, calculates the total payment amount, and creates a Jira ticket for payment processing with invoice details and LLO banking references. Currently requires manual invoice pulling from the Connect UI because the invoice API is not yet built. Uses Google Drive, Connect, and Jira (Atlassian) MCP tools.
+Pull invoices from the completed opportunity and create a Jira ticket to issue payment to the LLO. Currently requires manual invoice pulling from the Connect UI because the invoice API is not yet built. Uses Google Drive, Connect, and Jira (Atlassian) MCP tools.
 
 #### llo-feedback
 
-Collects feedback from LLOs about the completed opportunity. The skill composes feedback request emails covering app usability, process experience, FLW challenges, improvement suggestions, and interest in future opportunities. Sends from Ace-AI@Dimagi.com with admin group CC, monitors for responses via OCS transcripts, and documents all feedback with common themes. Currently generates email drafts for manual sending. Uses Google Drive and OCS MCP tools.
+Prompt LLOs for feedback about the application, process, and suggestions for next steps. Collect and document responses. Composes feedback request emails covering app usability, process experience, FLW challenges, improvement suggestions, and interest in future opportunities. Sends from Ace-AI@Dimagi.com with admin group CC, monitors for responses via OCS transcripts. Currently generates email drafts for manual sending. Uses Google Drive and OCS MCP tools.
 
 #### learnings-summary
 
-Synthesizes all information from the completed opportunity into actionable learnings. The skill reads the original IDD, test results, monitoring reports, data reviews, OCS transcripts, LLO feedback, and comms logs, then analyzes what worked, what did not, and whether success metrics were met. Produces four categories of learnings: process, content, technical, and relationship. If iteration is warranted, drafts a new IDD that can trigger another CRISPR-Connect cycle. Uses Google Drive and OCS MCP tools.
+Summarize learnings from the completed opportunity and create a new IDD if iteration is warranted. Can trigger another CRISPR-Connect cycle. Reads the original IDD, test results, monitoring reports, data reviews, OCS transcripts, LLO feedback, and comms logs, then analyzes what worked, what did not, and whether success metrics were met. Produces process, content, technical, and relationship learnings. Uses Google Drive and OCS MCP tools.
 
 #### cycle-grade
 
-Produces a final grade and assessment of the complete CRISPR-Connect cycle. Grades across six dimensions on a 0-10 scale: intervention effectiveness, app quality, LLO execution, FLW performance, process efficiency, and communication quality. Self-evaluates whether grading is fair and evidence-based. Generates top-3 successes, top-3 improvements, and per-skill recommendations. Emails the full cycle grade report to the admin group. Uses Google Drive MCP tools.
+Grade the overall CRISPR-Connect cycle with recommendations for improvements and next steps. **Archetype-aware** and **Evidence-Model-consuming**: reads the IDD's `archetype:` and `## Evidence Model` section in step 1 and uses Layer A as the source of FLW Performance evidence and Layer B/C as the source of Intervention Effectiveness / Research Quality evidence. For `atomic-visit`, grades 6 dimensions (intervention effectiveness, app quality, LLO execution, FLW performance, process efficiency, communication quality) with **FLW Performance** scored on submission volume / data quality / cap compliance. For `focus-group`, scores **FLW Performance** on facilitation quality (probing depth, balance, summary specificity, audio completeness) — *not* volume — and **Intervention Effectiveness** on research yield (theme specificity, segment differentiation, IDD research questions answered), and adds a 7th dimension: **Research Quality**. For `multi-stage`, grades each stage's archetype separately and produces an overall grade that also assesses stage-gate transitions. Self-evaluates grading fairness. Uses Google Drive MCP tools.
 
 ## External Integrations
 
 ### Connect API
 
-The connect-labs MCP provides approximately 20 production-ready tools for solicitations, reviews, awards, funds, and opportunity lookup. Key gaps that must be built (tracked as CCC-301): Program and Opportunity CRUD APIs (`create_program`, `create_opportunity`, etc.), opportunity configuration APIs (verification rules, delivery units, payment units), LLO invite API (`send_llo_invite`), and invoice API (`list_invoices`). The `connect-program-setup`, `connect-opp-setup`, `llo-invite`, and `opp-closeout` skills are blocked on these APIs and currently fall back to manual workflows.
+The connect-labs MCP provides approximately 20 production-ready tools for solicitations, reviews, awards, funds, and opportunity lookup. Key gaps that must be built (tracked as CCC-301): Program and Opportunity CRUD APIs (`create_program`, `create_opportunity`, etc.), opportunity configuration APIs (verification rules, delivery units, payment units), LLO invite API (`send_llo_invite`), and invoice API (`list_invoices`). The `connect-program-setup`, `connect-opp-setup`, `llo-invite`, and `opp-closeout` skills are blocked on these APIs and currently fall back to manual workflows. The "Experiment" generic delivery type is also a Connect-side prerequisite for focus-group opportunities.
 
 ### CommCare API
 
@@ -154,6 +194,17 @@ OCS is ACE's communication layer with LLOs. ACE creates an OCS agent per opportu
 ### Nova
 
 Nova generates CommCare applications from IDDs. The key open question is whether Nova can be driven programmatically (to be explored with Braxton). Three integration options exist in priority order: Nova REST API (preferred, fully automated), Nova fork with headless mode (viable but maintenance burden), or headless browser automation (not recommended, brittle). Until resolved, the `idd-to-learn-app` and `idd-to-deliver-app` skills generate structured app briefs for manual Nova interaction.
+
+## Test Fixtures
+
+ACE has two permanent synthetic test fixtures under `test/fixtures/`. Use these to regression-test skill changes before running on real opportunities. Always run with `--dry-run`.
+
+| Fixture | Archetype | Purpose |
+|---|---|---|
+| **CRISPR-Test-001** | `atomic-visit` | CHW training pilot for maternal/child health. Standard Learn + Deliver apps with per-beneficiary case management. Protects atomic-visit code paths. |
+| **CRISPR-Test-002** | `focus-group` | Simplified vaccine-hesitancy IDD (Stage 1 only, 2 segments, 1 LLO). Stress-test rubric all-pass, full Evidence Model declared. Protects focus-group code paths in the 7 archetype-aware skills. |
+
+Each fixture has a README documenting the expected per-skill behavior — the regression spec a human or future automated runner can compare against.
 
 ## Current Limitations
 
@@ -174,22 +225,24 @@ The following skills have manual workarounds due to APIs or integrations that ar
 
 ## Skill Reference
 
-| Skill | Description | MCP Tools | LLM-as-Judge | Has Workaround |
-|-------|-------------|-----------|:---:|:---:|
-| `idea-to-idd` | Iterate on an idea to produce an Intervention Design Doc | Google Drive | Yes | No |
-| `idd-to-learn-app` | Generate the Learn app from the IDD via Nova | Google Drive, Nova | Yes | Yes |
-| `idd-to-deliver-app` | Generate the Deliver app from the IDD via Nova | Google Drive, Nova | Yes | Yes |
-| `app-deploy` | Upload and publish apps to CommCare HQ | Google Drive, CommCare | No | Yes |
-| `app-test` | Test deployed apps against a generated test plan | Google Drive, CommCare | Yes | No |
-| `training-materials` | Generate LLO/FLW training docs from app summaries | Google Drive | Yes | No |
-| `connect-program-setup` | Create or select a Connect program | Google Drive, Connect | No | Yes |
-| `connect-opp-setup` | Create and configure a Connect opportunity | Google Drive, Connect | No | Yes |
-| `llo-invite` | Identify and invite LLOs to the opportunity | Google Drive, Connect | No | Yes |
-| `llo-onboarding` | Send onboarding emails to LLOs | Google Drive | No | Yes |
-| `ocs-agent-setup` | Configure an OCS agent for LLO support | Google Drive, OCS | Yes | Yes |
-| `timeline-monitor` | Check LLO progress against milestones (recurring) | Google Drive, Connect, CommCare/scout-data | Yes | No |
-| `flw-data-review` | Analyze FLW submission data for quality (recurring) | Google Drive, CommCare/scout-data, Connect | Yes | No |
-| `opp-closeout` | Pull invoices and create Jira payment ticket | Google Drive, Connect, Jira | No | Yes |
-| `llo-feedback` | Collect LLO feedback on the completed opportunity | Google Drive, OCS | No | Yes |
-| `learnings-summary` | Synthesize learnings; optionally draft new IDD | Google Drive, OCS | No | No |
-| `cycle-grade` | Grade the full cycle across 6 dimensions | Google Drive | Yes | No |
+| Skill | Description | MCP Tools | Archetype-aware | Reads Evidence Model | LLM-as-Judge | Has Workaround |
+|-------|-------------|-----------|:---:|:---:|:---:|:---:|
+| `idea-to-idd` | Iterate on an idea to produce an Intervention Design Doc | Google Drive | Yes | Writes it | Yes (5-question stress-test rubric) | No |
+| `idd-to-learn-app` | Generate the Learn app from the IDD via Nova | Google Drive, Nova | Yes | No | Yes | Yes |
+| `idd-to-deliver-app` | Generate the Deliver app from the IDD via Nova | Google Drive, Nova | Yes | No | Yes | Yes |
+| `app-deploy` | Upload and publish apps to CommCare HQ | Google Drive, CommCare | No | No | No | Yes |
+| `app-test` | Test deployed apps against a generated test plan | Google Drive, CommCare | Yes | Yes | Yes | No |
+| `training-materials` | Generate LLO/FLW training docs from app summaries | Google Drive | No | No | Yes | No |
+| `connect-program-setup` | Create or select a Connect program | Google Drive, Connect | No | No | No | Yes |
+| `connect-opp-setup` | Create and configure a Connect opportunity | Google Drive, Connect | Yes | Yes | No | Yes |
+| `llo-invite` | Identify and invite LLOs to the opportunity | Google Drive, Connect | No | No | No | Yes |
+| `llo-onboarding` | Send onboarding emails to LLOs | Google Drive | No | No | No | Yes |
+| `llo-uat` | Coordinate UAT with onboarded LLOs | Google Drive, OCS | No | No | No | No |
+| `llo-launch` | Verify UAT sign-offs and activate opportunity | Google Drive, Connect, CommCare | No | No | No | No |
+| `ocs-agent-setup` | Configure an OCS agent for LLO support | Google Drive, OCS | No | No | Yes | Yes |
+| `timeline-monitor` | Check LLO progress against milestones (recurring) | Google Drive, Connect, CommCare/scout-data | No | No | Yes | No |
+| `flw-data-review` | Analyze FLW submission data for quality (recurring) | Google Drive, CommCare/scout-data, Connect | Yes | Yes | Yes | No |
+| `opp-closeout` | Pull invoices and create Jira payment ticket | Google Drive, Connect, Jira | No | No | No | Yes |
+| `llo-feedback` | Collect LLO feedback on the completed opportunity | Google Drive, OCS | No | No | No | Yes |
+| `learnings-summary` | Synthesize learnings; optionally draft new IDD | Google Drive, OCS | No | No | No | No |
+| `cycle-grade` | Grade the full cycle across 6 (atomic-visit) or 7 (focus-group) dimensions | Google Drive | Yes | Yes | Yes | No |

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,206 @@
+# ACE Skills — Author Contract
+
+This file is the contract for authoring SKILL.md files in `skills/`. Read it before adding a new skill or making non-trivial edits to an existing one. Existing skills are the source of truth — if this contract drifts from them, fix the contract or fix the skills, but they should agree.
+
+ACE skills are prompt-based capability definitions. Each one handles one step of the CRISPR-Connect process (see `docs/superpowers/specs/2026-04-01-ace-design.md`). Skills are stateless — they read from and write to the opportunity's Google Drive folder (`ACE/<opp-name>/`) and call MCP tools for external system access. The agents in `agents/` are what dispatch to skills.
+
+## File location and naming
+
+Each skill lives in its own directory under `skills/`:
+
+```
+skills/
+└── <skill-name>/
+    └── SKILL.md
+```
+
+`<skill-name>` is kebab-case and matches the `name:` frontmatter field exactly. Multi-word names use single hyphens, not underscores. Names should be verbs or verb phrases ("idea-to-idd", "app-test", "llo-onboarding"), not nouns.
+
+If a skill needs supporting files (templates, scripts, prompt fragments), they go alongside `SKILL.md` in the same directory.
+
+## Required frontmatter
+
+Every SKILL.md begins with YAML frontmatter:
+
+```markdown
+---
+name: <skill-name>
+description: >
+  One-to-three-sentence description of what the skill does. This is what
+  /ace:docs renders into the generated playbook, so it must be readable
+  in isolation. Lead with the verb. Mention key inputs and outputs.
+---
+```
+
+- **`name`** (required) — must match the directory name
+- **`description`** (required) — readable standalone, 1–3 sentences, leads with the verb. The generated playbook (`docs/generated/playbook.md`) renders this verbatim, so it should be self-contained.
+
+No other frontmatter fields are required. Don't add `version:`, `author:`, or similar — git is the source of truth for authorship and history.
+
+## Required sections
+
+Every SKILL.md must have these sections, in this order:
+
+### 1. `# <Skill Display Name>` (h1)
+
+The h1 is the human-readable display name (e.g., "Idea to IDD"), not the kebab-case `name`. One short paragraph after the h1 restates the skill's purpose in plain language for someone who hasn't read the frontmatter.
+
+### 2. `## Process`
+
+A numbered list of steps the skill executes. Each step is a single imperative sentence in **bold**, optionally followed by a sub-bulleted breakdown of what the step entails. Steps should be sequential and the numbering must be sequential — if you insert a step in the middle of the list, renumber every step after it. Use `grep -nE '^[0-9]+\.' SKILL.md` to verify after edits.
+
+If the skill reads from the IDD's `archetype:` and/or `## Evidence Model` section, that read should be an explicit early step. Don't bury it in prose — it's load-bearing for downstream behavior.
+
+### 3. `## MCP Tools Used`
+
+A bullet list of MCP tools the skill calls, grouped by server. For each tool, indicate whether it's built or "NOT YET BUILT" (with the relevant ticket number when applicable). Example:
+
+```markdown
+## MCP Tools Used
+- Google Drive: `drive_read_file`, `drive_create_file`, `drive_update_file`
+- Connect: `create_opportunity`, `set_verification_rules` — **NOT YET BUILT** (CCC-301)
+```
+
+### 4. `## Mode Behavior`
+
+How the skill behaves in **Auto** vs **Review** mode. One bullet per mode. Both modes execute the same steps; only the gating and human-handoff differs.
+
+```markdown
+## Mode Behavior
+- **Auto:** <action>, notify admin group, proceed
+- **Review:** <action>, present for human approval, wait
+```
+
+### 5. `## Change Log`
+
+A markdown table of dated changes. Append at the bottom on every non-trivial edit. Don't delete history. Format:
+
+```markdown
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-04-03 | Initial version | ACE team |
+| 2026-04-08 | <description of change> | <author or context> |
+```
+
+Trivial typo fixes don't need a change log entry; behavior changes do. When in doubt, append.
+
+## Optional sections
+
+These are added when the skill needs them. They have a fixed location and format so the structure stays predictable across skills.
+
+### `## Archetypes` (when the skill branches on IDD delivery archetype)
+
+Required if the skill behaves differently for `atomic-visit` vs `focus-group` vs `multi-stage` IDDs. Place this section **immediately before** `## MCP Tools Used`.
+
+Each archetype is a `### <archetype-name>` subheading with a short description and the archetype-specific instructions. The default (`atomic-visit`) goes first. Skills that don't branch on archetype omit this section entirely.
+
+```markdown
+## Archetypes
+
+### `atomic-visit` (default)
+<what the skill does for atomic-visit IDDs>
+
+### `focus-group`
+<what the skill does differently for focus-group IDDs>
+
+### `multi-stage`
+<how the skill handles multi-stage IDDs — typically dispatches per stage>
+```
+
+The 7 archetype-aware skills today are: `idea-to-idd`, `idd-to-learn-app`, `idd-to-deliver-app`, `app-test`, `connect-opp-setup`, `flw-data-review`, `cycle-grade`.
+
+### `## LLM-as-Judge Rubric` (when the skill self-evaluates)
+
+Some skills self-evaluate their output before passing it downstream. When the rubric is non-trivial, factor it out into its own section instead of burying it inside a process step. Place this section **immediately before** `## Archetypes` (if present) or **immediately before** `## MCP Tools Used` (if not).
+
+The rubric should be concrete enough to grade on — bullet points with grading anchors, or a numbered checklist with pass/fail conditions. See `skills/idea-to-idd/SKILL.md` for the canonical example (the 5-question stress-test rubric with worked anchors from the example IDDs).
+
+### `## Current Workaround` (when the skill is blocked on un-built APIs)
+
+For skills whose ideal flow depends on APIs that don't exist yet, document the manual fallback. Place this **after** `## MCP Tools Used` and **before** `## Mode Behavior`. The workaround should be a numbered list of human-in-the-loop steps that produce the same external effect.
+
+Many existing skills have these blocks (everything blocked on CCC-301, Nova bot API, OCS MCP, etc.) — they're expected and not tech debt. They get removed once the underlying API ships.
+
+### `## Dry-Run Behavior` (when the skill has external side effects)
+
+Required for any skill that sends emails, publishes apps, creates Jira tickets, or otherwise produces external effects. Document what the skill does instead under `--dry-run`. Place this **after** `## Mode Behavior` and **before** `## Change Log`.
+
+```markdown
+## Dry-Run Behavior
+
+When `--dry-run` is active:
+- <full-action> is generated normally
+- <effectful-action> is written to `comms-log/dry-run-<step>.md` instead of executing
+- State tracks as `dry-run-success`
+```
+
+See `docs/superpowers/specs/2026-04-01-ace-design.md` § "Testing and Dry-Run Strategy" for the full dry-run model.
+
+## How the IDD `## Evidence Model` flows through skills
+
+The IDD template (`templates/idd-template.md`) declares an `## Evidence Model` section with three layers:
+
+- **Layer A — Delivery proof** (the thing happened): drives **verification rules** in `connect-opp-setup` and **capture-path tests** in `app-test`. Hard gates.
+- **Layer B — Content proof** (it was done properly): drives **content-quality tests** in `app-test` and **per-delivery review** in `flw-data-review`. Soft flags.
+- **Layer C — Cross-delivery quality** (the data is useful): drives **cross-delivery synthesis** in `flw-data-review` and **Intervention Effectiveness / Research Quality grading** in `cycle-grade`. Soft flags.
+
+If you're writing a skill that sets up verification, runs tests, reviews data, or grades quality, you almost certainly want to read the Evidence Model in your skill's first or second process step and use it as the spec rather than re-deriving from the IDD body. **If the IDD has no Evidence Model section, fail loudly** — that's a sign `idea-to-idd` skipped or short-circuited the stress-test rubric and the IDD shouldn't be propagating.
+
+## How to register a new archetype
+
+The 3 current archetypes are `atomic-visit`, `focus-group`, and `multi-stage`. Adding a new archetype is a framework-level change that touches ~3 places:
+
+1. **`templates/idd-template.md`** — add the new archetype to the `Archetype:` enum description and to the archetype-guidance block at the top of the template.
+2. **`skills/idea-to-idd/SKILL.md`** — add a `### <new-archetype>` subheading inside `## Archetypes` describing the additional questions to ask in step 3 and the archetype-specific sections to draft in step 4.
+3. **The 6 other archetype-aware skills** (`idd-to-learn-app`, `idd-to-deliver-app`, `app-test`, `connect-opp-setup`, `flw-data-review`, `cycle-grade`) — add a `### <new-archetype>` subheading inside `## Archetypes` describing how the skill behaves for the new archetype.
+
+Do **not** create a new skill per archetype. The whole point of the archetype mechanism is to avoid forking the framework — a new archetype is an additive change inside the existing 7 skills, not a fan-out of new skill files. (See Lesson 9 of the canopy `product-management` skill: *"Framework changes mean variation points, not new components."*)
+
+After adding a new archetype, add a regression fixture under `test/fixtures/` (mirror the structure of `CRISPR-Test-001` for `atomic-visit` and `CRISPR-Test-002` for `focus-group`).
+
+## Where shared templates and prompts live
+
+- `templates/` — IDD templates, email templates, training collateral templates. Read by skills that need a starting structure to populate.
+- `playbook/integrations/` — integration specs (Connect, CommCare, OCS, Nova) that document what's available, what's needed, and what manual workaround applies. Skills read these to know what APIs they can call.
+- `test/fixtures/` — synthetic opportunity fixtures for regression-testing skills. Each fixture has a README documenting expected per-skill behavior.
+
+Don't put shared prompt fragments in `skills/<skill-name>/`. If a fragment is shared, it belongs at the project root level (e.g., a `templates/` or `prompts/` directory at the repo root). Inline what's specific to one skill.
+
+## Worked examples
+
+When in doubt, copy from the closest existing skill:
+
+- **`skills/idea-to-idd/SKILL.md`** — canonical example of `## LLM-as-Judge Rubric` (the 5-question stress-test rubric with calibrated grading anchors) and `## Archetypes` (3 archetypes with required-section additions).
+- **`skills/connect-opp-setup/SKILL.md`** — canonical example of an Evidence-Model-consuming skill (reads Layer A in step 2, errors if missing) with archetype branching and a Current Workaround block.
+- **`skills/app-test/SKILL.md`** — canonical example of an Evidence-Model-consuming skill with archetype branching but no Current Workaround.
+- **`skills/cycle-grade/SKILL.md`** — canonical example of archetype branching that adds a 7th grading dimension (`Research Quality`) for one specific archetype.
+- **`skills/llo-onboarding/SKILL.md`** — canonical example of a simple skill with no archetype branching and no Evidence Model consumption.
+
+## Generated documentation
+
+`docs/generated/playbook.md` is generated from agent + skill definitions by the `/ace:docs` slash command. It pulls the `description:` frontmatter field of each SKILL.md verbatim, so the description is what the team and downstream consumers actually read. After non-trivial skill edits — especially edits to the description, the process, or the addition of `## Archetypes` / `## Evidence Model` consumption — re-run `/ace:docs` to refresh the playbook.
+
+## Checklist for a new skill
+
+Before committing a new SKILL.md, verify:
+
+- [ ] Directory name matches frontmatter `name`
+- [ ] Frontmatter has `name:` and `description:`; description leads with a verb and is readable in isolation
+- [ ] All five required sections present in order: `# <Display Name>` → `## Process` → `## MCP Tools Used` → `## Mode Behavior` → `## Change Log`
+- [ ] Process steps are numbered sequentially (`grep -nE '^[0-9]+\.' SKILL.md`)
+- [ ] If the skill branches on IDD archetype, `## Archetypes` is present with all 3 archetypes covered
+- [ ] If the skill consumes the IDD's Evidence Model, an explicit early process step reads it and errors if missing
+- [ ] If the skill has external side effects, `## Dry-Run Behavior` is present
+- [ ] If the skill is blocked on un-built APIs, `## Current Workaround` is present
+- [ ] Initial change log entry exists with the date and author
+- [ ] If the skill is archetype-aware and a focus-group fixture exists, the `test/fixtures/CRISPR-Test-002/README.md` regression spec covers it
+
+## Checklist for editing an existing skill
+
+- [ ] Step numbering verified after any insertion (`grep -nE '^[0-9]+\.' SKILL.md`)
+- [ ] Change log appended with date, change description, author/context
+- [ ] If you changed the `description:` frontmatter or the Process, plan to re-run `/ace:docs`
+- [ ] If you changed archetype branching, dry-run the affected fixtures (`CRISPR-Test-001` for atomic-visit, `CRISPR-Test-002` for focus-group) and update fixture READMEs if behavior expectations changed
+- [ ] If you added a new MCP tool dependency, mark it as built or "NOT YET BUILT" with the ticket number

--- a/test/fixtures/CRISPR-Test-001/connect-setup/program.md
+++ b/test/fixtures/CRISPR-Test-001/connect-setup/program.md
@@ -1,0 +1,16 @@
+# Connect Program — CRISPR-Test-001
+
+> Synthetic Connect program stub. Written by `connect-program-setup` after the Program is created or selected in Connect. Used downstream by `connect-opp-setup`. For the test fixture, all IDs and URLs are fake.
+
+## Program
+
+- **Name:** TestLand CHW Training Pilot
+- **Program ID:** `prog-fake-001`
+- **Workspace:** CRISPR-Connect (sandbox)
+- **Status:** active
+- **URL:** https://connect-staging.dimagi.org/programs/prog-fake-001
+
+## Notes
+
+- Reused for the CRISPR-Test-001 atomic-visit fixture
+- Test fixture only — do not use against production Connect

--- a/test/fixtures/CRISPR-Test-001/deployment-summary.md
+++ b/test/fixtures/CRISPR-Test-001/deployment-summary.md
@@ -1,0 +1,22 @@
+# Deployment Summary — CRISPR-Test-001
+
+> Synthetic deployment-summary stub. Written by `app-deploy` after the Learn + Deliver apps are uploaded to CommCare HQ. Used downstream by `app-test` and `connect-opp-setup`. For the test fixture, all IDs and URLs are fake.
+
+## Deployed apps
+
+| App | Type | App ID | Build | Status | URL |
+|---|---|---|---|---|---|
+| CHW Training (Learn) | Learn | `app-fake-learn-001` | 12 | published | https://www.commcarehq.org/a/crispr-test/apps/view/app-fake-learn-001/ |
+| CHW Visits (Deliver) | Deliver | `app-fake-deliver-001` | 8 | published | https://www.commcarehq.org/a/crispr-test/apps/view/app-fake-deliver-001/ |
+
+## Domain
+
+- **Domain:** `crispr-test`
+- **Project space:** TestLand pilot
+- **Build environment:** sandbox (do not use against production CCHQ)
+
+## Notes
+
+- Learn app must be completed before the Deliver app is unlocked for the FLW
+- All form submissions land in the `crispr-test` domain
+- Test fixture only — do not use these app IDs against real CCHQ

--- a/test/fixtures/CRISPR-Test-001/idd.md
+++ b/test/fixtures/CRISPR-Test-001/idd.md
@@ -3,6 +3,7 @@
 ## Opportunity: Community Health Worker Training Pilot — TestLand
 **Date:** 2026-03-15
 **Author:** Neal (ACE test fixture)
+**Archetype:** atomic-visit
 
 ---
 
@@ -70,6 +71,14 @@ Deploy a Learn + Deliver model where CHWs first complete training modules on MCH
 | Visit coverage | 80% of beneficiaries visited on schedule | Deliver app submission rates |
 | Data quality | <5% forms with missing required fields | CommCare data quality reports |
 | Referral appropriateness | >90% referrals clinically justified | Clinic record cross-check |
+
+## Evidence Model
+
+| Layer | Purpose | Captured by | Verified by |
+|---|---|---|---|
+| **A — Delivery proof** | The CHW visited the beneficiary and completed the appropriate form | Visit form submission (Prenatal Visit / Immunization Visit / Danger Sign Referral), GPS coordinate, timestamp, case ID, all required fields populated | Automated: GPS within target district, all required fields non-empty, case lifecycle action consistent (registration creates, follow-up updates), submission time within working hours |
+| **B — Content proof** | The visit was conducted properly and the data is plausible | BP reading within physiologically possible range, vaccine batch number format valid, danger signs checklist complete with at least one entry where flagged, referral form attached when danger signs are present | Automated + AI-assisted: range checks on numeric fields, batch-number regex, conditional-required-field enforcement, referral cross-check |
+| **C — Cross-delivery quality** | The dataset is useful and the FLWs are performing consistently | Per-FLW visit volume vs. cohort baseline, per-FLW referral rate vs. cohort baseline, case dropout patterns, data quality drift over time | AI advisory: outlier detection per FLW, referral-rate plausibility (too-low = under-referring, too-high = over-referring), case-dropout cluster detection |
 
 ## Timeline
 - Start date: 2026-04-01

--- a/test/fixtures/CRISPR-Test-001/idea.md
+++ b/test/fixtures/CRISPR-Test-001/idea.md
@@ -1,0 +1,5 @@
+# Initial Idea — CRISPR-Test-001
+
+> Synthetic idea for the atomic-visit fixture. Used as input to `idea-to-idd` if testing the full lifecycle from step 1.
+
+Pilot a Community Health Worker (CHW) training-and-deployment program in TestLand's Eastern Province, where rural clinics lack systematic CHW training for maternal and child health (MCH) services. Train CHWs in prenatal assessment, immunization tracking, and danger-sign recognition via a Connect Learn app. Then deploy a Connect Deliver app for FLWs to use during home visits — registering pregnant women and children under 5, conducting monthly prenatal assessments, tracking immunizations, and triggering emergency referrals when danger signs are observed. Goal: standardize CHW protocol and capture outcome data so we can measure whether structured FLW visits improve referral rates and immunization coverage in the pilot districts.

--- a/test/fixtures/CRISPR-Test-001/state.yaml
+++ b/test/fixtures/CRISPR-Test-001/state.yaml
@@ -2,6 +2,7 @@ opportunity: CRISPR-Test-001
 mode: review
 created: 2026-04-03T00:00:00Z
 type: synthetic-test-fixture
+archetype: atomic-visit
 
 steps:
   idea-to-idd: pending

--- a/test/fixtures/CRISPR-Test-002/connect-setup/program.md
+++ b/test/fixtures/CRISPR-Test-002/connect-setup/program.md
@@ -1,0 +1,17 @@
+# Connect Program — CRISPR-Test-002
+
+> Synthetic Connect program stub. Written by `connect-program-setup` after the Program is created or selected in Connect. Used downstream by `connect-opp-setup`. For the test fixture, all IDs and URLs are fake.
+
+## Program
+
+- **Name:** TestLand Vaccine Hesitancy Research
+- **Program ID:** `prog-fake-002`
+- **Workspace:** CRISPR-Connect (sandbox)
+- **Status:** active
+- **URL:** https://connect-staging.dimagi.org/programs/prog-fake-002
+
+## Notes
+
+- Created for the CRISPR-Test-002 focus-group fixture
+- Program is configured to allow the "Experiment" generic delivery type required by focus-group opportunities
+- Test fixture only — do not use against production Connect

--- a/test/fixtures/CRISPR-Test-002/deployment-summary.md
+++ b/test/fixtures/CRISPR-Test-002/deployment-summary.md
@@ -1,0 +1,23 @@
+# Deployment Summary — CRISPR-Test-002
+
+> Synthetic deployment-summary stub. Written by `app-deploy` after the Learn + Deliver apps are uploaded to CommCare HQ. Used downstream by `app-test` and `connect-opp-setup`. For the test fixture, all IDs and URLs are fake.
+
+## Deployed apps
+
+| App | Type | App ID | Build | Status | URL |
+|---|---|---|---|---|---|
+| Focus Group Facilitation Training (Learn) | Learn | `app-fake-fg-learn-002` | 5 | published | https://www.commcarehq.org/a/crispr-test/apps/view/app-fake-fg-learn-002/ |
+| Focus Group Session Documentation (Deliver) | Deliver | `app-fake-fg-deliver-002` | 4 | published | https://www.commcarehq.org/a/crispr-test/apps/view/app-fake-fg-deliver-002/ |
+
+## Domain
+
+- **Domain:** `crispr-test`
+- **Project space:** TestLand pilot
+- **Build environment:** sandbox (do not use against production CCHQ)
+
+## Archetype-specific notes
+
+- **Learn app** is the 8-module facilitation training (not a form walkthrough). Facilitators must complete all 8 modules and pass each knowledge check before being marked session-ready.
+- **Deliver app** is a session documentation form (not per-beneficiary). The case structure is per-segment, not per-participant.
+- File upload endpoints are configured for both audio (`.m4a` / `.mp4`) and attendance photos.
+- Test fixture only — do not use these app IDs against real CCHQ.

--- a/test/fixtures/CRISPR-Test-002/idea.md
+++ b/test/fixtures/CRISPR-Test-002/idea.md
@@ -1,0 +1,5 @@
+# Initial Idea — CRISPR-Test-002
+
+> Synthetic idea for the focus-group fixture. Used as input to `idea-to-idd` if testing the full lifecycle from step 1.
+
+Run focus group discussions with caregivers in TestLand's Eastern Province (Luvale + Kaonde districts) to understand the underlying drivers of childhood under-vaccination. Existing health-records data tells us *that* vaccination is below target but not *why* — we don't know which barriers are dominant (access, cost, opportunity cost, social influence, religious objections, gender dynamics, mistrust) or how they vary across community segments. Recruit 2 segments (women close to a primary health center with under-vaccinated children; men remote from PHCs with mixed vaccination status) and run 3 focus group sessions per segment, facilitated by trained community-engagement staff in Hausa, with audio recording and per-domain summary capture. Synthesize findings across sessions to produce a barriers-and-enablers report. The output should be specific enough to inform a follow-on Stage-2 household intervention (which will be a separate opportunity if findings warrant it).

--- a/test/fixtures/CRISPR-Test-002/validation-2026-04-08.md
+++ b/test/fixtures/CRISPR-Test-002/validation-2026-04-08.md
@@ -1,0 +1,220 @@
+# CRISPR-Test-002 — Walk-Through Validation (2026-04-08)
+
+This is a manual walk-through validation of the focus-group framework changes (jjackson/ace#4) against the CRISPR-Test-002 fixture. I read each archetype-aware SKILL.md and simulated executing it against the fixture's files, then compared the simulated output to the regression spec in the fixture's `README.md`.
+
+**This is not an actual `/ace:run`** — that requires invoking the plugin from a separate Claude session with the GDrive MCP active. This walk-through is the next-best validation: it confirms the SKILL.md instructions are internally consistent, that the fixture has the inputs each skill needs, and that the regression spec matches what each skill is actually instructed to produce.
+
+## Result summary
+
+| Skill | Inputs available? | Process consistent? | Output matches spec? | Notes |
+|---|---|---|---|---|
+| `idea-to-idd` | Yes (after fix below) | Yes | Yes | Required adding `idea.md` to the fixture |
+| `idd-to-learn-app` | Yes | Yes | Yes | — |
+| `idd-to-deliver-app` | Yes | Yes | Yes | — |
+| `app-test` | Yes (after fix below) | Yes | Yes | Required adding `deployment-summary.md` |
+| `connect-opp-setup` | Yes (after fix below) | Yes | Yes | Required adding `connect-setup/program.md` and `deployment-summary.md` |
+| `flw-data-review` | Partial | Yes | N/A — needs runtime data | Fixture has no synthetic submission data |
+| `cycle-grade` | Partial | Yes | N/A — needs runtime data | Fixture is in pending state, not completed state |
+
+**Bottom line:** 5 of 7 archetype-aware skills can be validated against the fixture in its current form. The remaining 2 (`flw-data-review`, `cycle-grade`) need runtime data — either fake completed sessions and a closed-out opportunity state, or a separate "completed" companion fixture. These gaps existed in CRISPR-Test-001 too and predate this PR; they're noted at the bottom of this report under **Known fixture limitations**.
+
+## Fixture additions made during validation
+
+These were missing inputs that prevented end-to-end runnability. Added to **both** CRISPR-Test-001 and CRISPR-Test-002 since the gaps were pre-existing and symmetric:
+
+1. **`idea.md`** — synthetic initial idea, used as input to `idea-to-idd`. Without this, `idea-to-idd` step 1 has nothing to read.
+2. **`deployment-summary.md`** — synthetic deployment record (fake CommCare app IDs and URLs), used as input by `app-test` and `connect-opp-setup`. Without this, those skills error at the input-reading step.
+3. **`connect-setup/program.md`** — synthetic Connect program record (fake program ID and URL), used as input by `connect-opp-setup`. Same reason.
+
+These are stubs only; real values would be populated by running the upstream skills. The stubs make the fixtures self-contained for downstream-skill testing.
+
+## Per-skill walk-through
+
+### 1. `idea-to-idd`
+
+**Inputs read:** `idea.md` (added during validation).
+
+**Process trace:**
+- Step 1 reads the idea ✓
+- Step 2 determines archetype from the idea text — vaccine-hesitancy focus groups → `focus-group`
+- Step 3 expands the idea, working through the focus-group additional questions in `## Archetypes`: recruitment, language, facilitation skill, consent, venue, duration/compensation, question guide, output spec
+- Step 4 drafts the IDD with base sections + focus-group additional sections (Recruitment Plan, Facilitation Protocol, Question Guide, Output Specification)
+- Step 5 runs the 5-question stress-test rubric
+- Step 6 writes the IDD with `## Stress Test Results` appendix
+
+**Expected output:** an IDD structurally equivalent to `test/fixtures/CRISPR-Test-002/idd.md`, with all 5 stress-test checks passing (the fixture was constructed to pass).
+
+**Comparison with fixture spec:** ✓ The fixture's `idd.md` is an instance of what `idea-to-idd` should produce for a focus-group archetype with all gaps resolved. The README spec ("reads `archetype: focus-group`, drafts focus-group additional sections, runs the rubric, all-pass") matches the SKILL.md process exactly.
+
+**Caveat:** This skill is non-deterministic (LLM output varies). The validation here is structural ("the output should have these sections, the rubric should grade these results"), not literal ("the output should equal idd.md byte-for-byte"). The fixture's idd.md is a *target shape*, not a golden output.
+
+### 2. `idd-to-learn-app`
+
+**Inputs read:** `idd.md`.
+
+**Process trace:**
+- Step 1 reads the IDD ✓
+- Step 2 extracts Learn app requirements; `## Archetypes` → `focus-group` → "facilitation training app, not form walkthrough"
+- Step 3 generates a Nova brief that explicitly references the IDD's Facilitation Protocol section and lists the 8 modules from the IDD's Learn App Specification
+- Step 4 (workaround active — Nova bot API not built) writes the brief to `ACE/CRISPR-Test-002/app-briefs/learn-app-brief.md`
+- Step 5 self-evaluates whether the brief is a facilitation-training brief (not a form walkthrough)
+- Step 6 writes the app summary
+
+**Expected output:** A Nova brief describing the 8-module facilitation training app with the modules from the IDD's Learn App Specification:
+1. Facilitation basics
+2. Probing techniques
+3. Neutral framing
+4. Group dynamics
+5. Question guide walkthrough
+6. Session form walkthrough
+7. Consent and ethics
+8. Logistics
+
+**Comparison with fixture spec:** ✓ The fixture's `app-summaries/learn-app-summary.md` already documents the expected 8-module structure. The README spec ("brief explicitly references the Facilitation Protocol section, includes the 8 modules, does not generate a generic data-collection-form-walkthrough brief") matches.
+
+### 3. `idd-to-deliver-app`
+
+**Inputs read:** `idd.md`.
+
+**Process trace:**
+- Step 1 reads the IDD ✓
+- Step 2 extracts Deliver app requirements; `## Archetypes` → `focus-group` → "session documentation, segment-level case"
+- Step 3 generates a Nova brief that explicitly references the IDD's Output Specification section and describes the form structure: pre-session, per-question-domain (×6), post-session, with case at segment level
+- Step 4 (workaround) writes the brief
+- Step 5 self-evaluates
+- Step 6 writes the app summary
+
+**Expected output:** A Nova brief describing a session-documentation form mirroring the structure in `app-summaries/deliver-app-summary.md` — three forms (Session start, Per-domain summary ×6, Session end), case management at segment level.
+
+**Comparison with fixture spec:** ✓ Aligned. The fixture's `deliver-app-summary.md` was hand-written to be the spec. The SKILL.md instructs the brief to call out "session documentation, not atomic data collection."
+
+### 4. `app-test`
+
+**Inputs read:** `app-summaries/learn-app-summary.md`, `app-summaries/deliver-app-summary.md`, `deployment-summary.md` (added during validation), `idd.md`.
+
+**Process trace:**
+- Step 1 reads app summaries ✓
+- Step 2 reads deployment details ✓
+- Step 3 reads `archetype: focus-group` and the IDD's Evidence Model section. Errors out if Evidence Model is missing — fixture has it ✓
+- Step 4 generates the test plan; `## Archetypes` → `focus-group` → covers per-domain section coverage, file-upload paths, consent gating, segment-level case lifecycle. Layer A entries from the Evidence Model become capture tests.
+- Step 5 executes tests (in dry-run, generates the plan only)
+- Step 6 self-evaluates with the new check "does every Layer A artifact have a passing capture test?"
+- Step 7 writes test results, with each test case linked back to its Evidence Model layer
+
+**Expected output:** A test plan with explicit Layer A capture tests covering:
+- GPS-within-target-area capture
+- Audio file present and ≥ 45 min duration
+- Attendance form complete
+- All 6 per-domain summary forms submitted
+- Consent confirmation present
+- Facilitator reflection present
+
+Plus content validation tests on free-text fields (themes, quotes, facilitator reflection — paragraph-length acceptance), file-upload end-to-end tests, consent gating tests, segment-level case lifecycle tests.
+
+**Comparison with fixture spec:** ✓ The README spec lists exactly these test categories. The SKILL.md → fixture mapping is clean.
+
+### 5. `connect-opp-setup`
+
+**Inputs read:** `idd.md`, `connect-setup/program.md` (added during validation), `deployment-summary.md` (added during validation).
+
+**Process trace:**
+- Step 1 reads inputs ✓
+- Step 2 reads `archetype: focus-group` and the IDD's Evidence Model. Errors if Evidence Model is missing — fixture has it ✓
+- Step 3 creates the opportunity (workaround active — `create_opportunity` API not built); `## Archetypes` → `focus-group` → uses delivery type "Experiment"
+- Step 4 configures verification rules from Layer A. Each Layer A row in the fixture's Evidence Model maps to one rule.
+- Step 5 configures delivery units; `## Archetypes` → `focus-group` → delivery unit = one completed session (not one participant); total count = 6 sessions from the IDD
+- Step 6 configures payment units (per-session, $500/session)
+- Step 7 writes the opportunity config summary
+
+**Expected output:** An opportunity config spec with:
+- Delivery type: "Experiment"
+- Delivery unit: one completed focus-group session
+- Payment unit count: 6 (= IDD's planned session count)
+- Verification rules quoting Evidence Model Layer A:
+  - GPS within target community area
+  - Audio file present, duration ≥ 45 minutes
+  - Attendance form complete
+  - All 6 per-domain summary forms submitted
+  - Consent confirmation present
+  - Facilitator reflection present
+- Soft flags from Layer B/C: AI quality check on per-domain summaries, segment differentiation
+
+**Comparison with fixture spec:** ✓ The README spec is a 1:1 match with the SKILL.md instructions. The fixture's IDD has all 6 Layer A rows that should become rules.
+
+### 6. `flw-data-review` *(partial — needs runtime data)*
+
+**Inputs read:** app summaries ✓, idd.md (with archetype + Evidence Model) ✓, **fake submission data** *(NOT in fixture)*.
+
+**Process trace:**
+- Step 1 reads context including archetype and Evidence Model. Branches to `focus-group` qualitative review.
+- Step 2 queries FLW data via scout-data MCP. **This is where the walk-through stops** — the fixture has no synthetic completed-session data to query against.
+- (Steps 3–6 would self-evaluate, generate recommendations, write the review)
+
+**Why this is a partial:** Validating `flw-data-review` requires synthetic completed sessions in the fixture — at minimum, 3–6 fake "session output" records with realistic per-domain summaries, quotes, attendance, and audio metadata. These would mirror what the Deliver app would actually capture in production. They don't exist yet.
+
+**What the skill *would* do** if the data existed (verified by reading the SKILL.md):
+- Per-session quality review: are summaries specific or generic? Are quote counts ≥ 2 per domain? Is the facilitator reflection substantive?
+- Cross-session synthesis: themes by segment, convergence/divergence between the two segments, saturation indicator, top barriers with quote attribution, implications for a Stage 2 IDD
+- Quote bank extraction
+- Facilitator coaching signals
+- **Does NOT** run quantitative checks (submission rates, outlier detection, daily caps)
+
+**Comparison with fixture spec:** ✓ The README spec describes exactly this qualitative review. The SKILL.md → spec mapping is correct on paper; the missing piece is runtime data.
+
+**Recommendation:** Create a `test/fixtures/CRISPR-Test-002-completed/` companion fixture with 6 fake session-output records. Out of scope for this PR; logged as a follow-up.
+
+### 7. `cycle-grade` *(partial — needs runtime data)*
+
+**Inputs read:** all opportunity artifacts including learnings-summary, idd.md (with archetype + Evidence Model). **Fixture has none of the completed-cycle artifacts** (test results, monitoring reports, FLW data reviews, OCS transcripts, LLO feedback, learnings summary).
+
+**Process trace:**
+- Step 1 reads all artifacts. **This is where the walk-through stops** — the fixture has only the inputs to the *first* skill in the cycle, not the outputs of all 19.
+- (Steps 2–6 would grade across dimensions, self-evaluate, generate recommendations, write the report, email)
+
+**Why this is a partial:** Validating `cycle-grade` requires the fixture to be in a "completed" state with all the artifacts the grader reads. The fixture is in a "pending" state (per state.yaml). This is the same gap CRISPR-Test-001 has — neither fixture is currently set up for end-of-cycle skill testing.
+
+**What the skill *would* do** if all artifacts existed (verified by reading the SKILL.md):
+- Read the IDD's Evidence Model; Layer A → FLW Performance evidence; Layer B/C → Intervention Effectiveness / Research Quality evidence
+- For `focus-group`, grade 7 dimensions (the standard 6 + Research Quality). Use facilitation-quality rubric for FLW Performance, research-yield rubric for Intervention Effectiveness.
+- Self-evaluate fairness
+- Write the cycle grade report and email the admin group
+
+**Comparison with fixture spec:** ✓ The README spec aligns with the SKILL.md. Missing piece is the completed-state artifacts.
+
+**Recommendation:** Same as flw-data-review — a "completed" companion fixture or runtime artifact synthesis. Out of scope for this PR; logged as a follow-up.
+
+## Issues found during validation
+
+### None affecting the merged framework changes
+
+The walk-through did not surface any inconsistencies between the SKILL.md instructions and the fixture spec. The 5 fully-validatable skills (idea-to-idd, idd-to-learn-app, idd-to-deliver-app, app-test, connect-opp-setup) all have clean process traces against the fixture inputs, and each skill's output (per its SKILL.md) matches what the fixture README claims it should produce.
+
+The 2 partially-validatable skills (flw-data-review, cycle-grade) are blocked on missing runtime data, not on framework or skill bugs. Their SKILL.md → spec mapping is internally consistent.
+
+### Pre-existing fixture gaps (not regressions)
+
+These gaps existed in CRISPR-Test-001 before this PR and were inherited symmetrically by CRISPR-Test-002:
+
+1. ~~No `idea.md` in either fixture~~ → **fixed in this PR** (added stubs to both)
+2. ~~No `deployment-summary.md` in either fixture~~ → **fixed in this PR** (added stubs to both)
+3. ~~No `connect-setup/program.md` in either fixture~~ → **fixed in this PR** (added stubs to both)
+4. **No fake submission data in either fixture** → not fixed; would block `flw-data-review` testing on either fixture. Logged as follow-up.
+5. **Neither fixture is in a "completed" state** → not fixed; would block `cycle-grade`, `learnings-summary`, `opp-closeout`, `llo-feedback` testing. Logged as follow-up.
+
+## Known fixture limitations
+
+These are out of scope for the focus-group framework PR but should be tracked as follow-up work to make the fixtures fully end-to-end testable:
+
+| Limitation | Affects | Effort | Notes |
+|---|---|---|---|
+| No synthetic submission data | `flw-data-review` (both fixtures) | M | For atomic-visit: fake CommCare submissions. For focus-group: fake session output records with realistic per-domain summaries. |
+| No "completed-state" companion fixture | `cycle-grade`, `learnings-summary`, `opp-closeout`, `llo-feedback` | L | Would need a `CRISPR-Test-001-completed` and `CRISPR-Test-002-completed` with all the post-execution artifacts. Or add a "post-run" mode to the existing fixtures. |
+| No automated regression script | All skills | L | Currently each fixture run is manual. ACE's existing eval framework (`test/eval/`) is for Nova blueprints, not SKILL.md prompt outputs. A regression script would diff dry-run outputs against expected behaviors documented in the fixture READMEs. |
+
+## Conclusion
+
+**The focus-group framework changes are validated** for the 5 skills that can be walked through against the fixture (idea-to-idd, idd-to-learn-app, idd-to-deliver-app, app-test, connect-opp-setup). The SKILL.md instructions, the fixture inputs, and the fixture README's regression spec are all internally consistent and produce the same expected outputs.
+
+The 2 remaining skills (flw-data-review, cycle-grade) are validated *on paper* (the SKILL.md → spec mapping is correct) but cannot be runtime-validated without additional fixture content. This is a pre-existing limitation that affects atomic-visit testing equally — fixing it is a separate, larger effort than this PR.
+
+Three small fixture gaps (`idea.md`, `deployment-summary.md`, `program.md`) were found during validation and are fixed in this PR for both fixtures.


### PR DESCRIPTION
## Summary

Wraps up the deferred items from #4: skill author contract, regenerated playbook, fixture-symmetry fixes, and a walk-through validation report.

## Changes

### 1. \`skills/README.md\` (new)

One-page author contract for SKILL.md files. Defines required frontmatter and sections, optional sections (\`## Archetypes\`, \`## LLM-as-Judge Rubric\`, \`## Current Workaround\`, \`## Dry-Run Behavior\`), how the IDD's Evidence Model flows through skills, how to register a new archetype (the variation-points-not-new-components rule), and worked-example pointers. Includes a checklist for new skills and a checklist for editing existing skills. References Lesson 9 from canopy-skills (which got merged from this same scout cycle as canopy-skills#9).

### 2. \`docs/generated/playbook.md\` (regenerated)

Refreshed by hand to mirror what \`/ace:docs\` would now produce post-#4. \`/ace:docs\` is a slash command (Claude prompt), not a script, so this is the regeneration step. Highlights:

- New **Skill Framework** section explaining delivery archetypes, Evidence Model layers (A/B/C), and the stress-test rubric
- Per-skill descriptions updated for all 7 archetype-aware skills (now flagged as \"Archetype-aware\" / \"Evidence-Model-consuming\")
- New **Test Fixtures** section listing CRISPR-Test-001 and CRISPR-Test-002 with their archetypes
- Process Flow table gains an \"Archetype-aware\" column
- Skill Reference table gains \"Archetype-aware\" + \"Reads Evidence Model\" columns
- Skill count corrected from 17 → 19 (the previous render was missing \`llo-uat\` and \`llo-launch\`)
- Generated date bumped to 2026-04-08

### 3. CRISPR-Test-001 (atomic-visit fixture)

- \`idd.md\`: declares \`Archetype: atomic-visit\` explicitly (was previously relying on the default fallback). Also gets a full \`## Evidence Model\` section (Layer A/B/C) covering CHW visit completeness, content plausibility, and cross-FLW quality. The Evidence Model is **required** for downstream skills now (\`connect-opp-setup\`, \`app-test\`, \`flw-data-review\`, \`cycle-grade\` all error if it's missing — this was added in #4) so without this change CRISPR-Test-001 would silently break.
- \`state.yaml\`: gets the archetype field
- \`idea.md\` (new): synthetic initial idea, used as input to \`idea-to-idd\`
- \`deployment-summary.md\` (new): synthetic deployment record (fake CommCare app IDs and URLs), used by \`app-test\` and \`connect-opp-setup\`
- \`connect-setup/program.md\` (new): synthetic Connect program record (fake program ID and URL), used by \`connect-opp-setup\`

### 4. CRISPR-Test-002 (focus-group fixture)

Mirrors the 3 new files added to CRISPR-Test-001 above (idea.md, deployment-summary.md, program.md), plus a walk-through validation report.

### 5. \`test/fixtures/CRISPR-Test-002/validation-2026-04-08.md\`

Walk-through validation of all 7 archetype-aware skills against CRISPR-Test-002. Result: **5 of 7 fully validated on paper** (idea-to-idd, idd-to-learn-app, idd-to-deliver-app, app-test, connect-opp-setup). The remaining 2 (flw-data-review, cycle-grade) need runtime data — flw-data-review needs synthetic submission data, cycle-grade needs a completed-state fixture. These are pre-existing fixture limitations that affect atomic-visit testing equally.

The validation found and documented three pre-existing fixture gaps (the missing idea.md, deployment-summary.md, and program.md files) and fixed them in this PR for both fixtures.

## Why these are stubs

The new files added to both fixtures (idea.md, deployment-summary.md, program.md) are **stubs only**. Real values are populated by running the upstream skills. The stubs make both fixtures self-contained for testing downstream skills without requiring an end-to-end run.

## Test plan

- [ ] Re-read \`skills/README.md\` against an existing SKILL.md (e.g., \`skills/idea-to-idd/SKILL.md\`) and confirm the contract matches
- [ ] Re-read \`docs/generated/playbook.md\` against the actual SKILL.md descriptions and confirm nothing drifted
- [ ] Manually walk through CRISPR-Test-001 with the new fixture files in place — confirm \`connect-opp-setup\` no longer errors on missing Evidence Model
- [ ] Optional: actually invoke \`/ace:run CRISPR-Test-001 --dry-run\` and \`/ace:run CRISPR-Test-002 --dry-run\` from a separate Claude session and compare outputs against the validation report's per-skill expected behaviors

## Follow-ups noted (not in this PR)

- Synthetic submission data for both fixtures (would unblock \`flw-data-review\` runtime testing)
- Completed-state companion fixtures (would unblock \`cycle-grade\`, \`learnings-summary\`, \`opp-closeout\`, \`llo-feedback\` runtime testing)
- Automated regression script (currently each fixture is manually walked through)
- Re-running \`/ace:docs\` periodically — or wiring it into a hook so it auto-regenerates on \`skills/\` changes

## Related

- Builds on #4 (focus-group framework primitives)
- canopy-skills#7, #8, #9 (universal-improvement PRs from the same scout cycle, all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)