### PR TITLE
chore(pm): commit .claude/pm/ so PM state carries forward across sessions

### DIFF
--- a/.claude/pm/context.md
+++ b/.claude/pm/context.md
@@ -1,0 +1,32 @@
+# ACE — Product Context
+
+## What It Is
+ACE (AI Connect Engine) is a Claude Code plugin that orchestrates the 21-step CRISPR-Connect lifecycle for Connect opportunities — from idea through IDD, Nova app generation, CommCare deployment, LLO onboarding, monitoring, and closeout.
+
+## Who Uses It
+- **Primary users**: Dimagi CRISPR admin group (Matt, Neal, Jon, Sarvesh, Cal). They run ACE against individual Connect opportunities, review outputs at gate steps, and merge skill improvements back into the plugin repo.
+- **Indirect users**: LLOs and FLWs whose work ACE generates and monitors — they don't touch ACE directly.
+- **Usage pattern**: One ACE instance per Connect opportunity, run in "review" mode with human approval at gates (IDD, app deploy, LLO invite). Skills improve continuously via edits → PR → merge, same as canopy.
+
+## What Matters Most
+1. **Time from idea to LLO go-live ≤ 1 week** with minimal Dimagi intervention by end of Q2 2026.
+2. **Zero "bad sends"** — no emails, publishes, or invites that had to be recalled.
+3. **Skills that generalize** — ACE should handle IDDs beyond the atomic-visit pattern (focus groups, qualitative research, longitudinal pilots) without hard-forking the skill set per IDD type.
+
+## Tech Stack
+- Claude Code plugin: agents + skills (SKILL.md) + commands, canopy-style
+- 5 agents (ace-orchestrator + 4 phase), 19 skills, 4 commands
+- 2 MCP servers: Google Drive (built, TS/Node), OCS (scaffold stubs)
+- External deps: connect-labs MCP (~20 tools, gaps tracked as CCC-301), Nova (bot API TBD), CommCare HQ, OCS, Jira
+- Companion repo: `ace-web` (Django + Channels + React on GCP Cloud Run) — browser chat/transcript harness, separate repo
+
+## Current State
+All 19 SKILL.md stubs exist with process steps, tool lists, mode behavior, change logs. Many skills carry "current workaround" sections because underlying APIs (Program/Opp creation, Nova bot, OCS, CommCare upload/publish) aren't built yet — they degrade gracefully to human-in-the-loop. Eval framework exists (IDD → Nova → Blueprint at 88%). Dry-run mode + CRISPR-Test-001 fixture + structural validation landed recently. Most recent work (PR #3) added two sample IDDs that stress-test the framework: a clean case (turmeric market survey) and a hard case (vaccine hesitancy focus groups) that exposed gaps in current skill assumptions.
+
+## Known Considerations
+- **Atomic-visit bias:** every current skill implicitly assumes "delivery = one FLW visit = photo + GPS + form." Focus-group and other qualitative IDDs don't fit. See `docs/examples/idd-stress-test-observations.md`.
+- **Manual fallbacks are expected, not tech debt.** Most "NOT YET BUILT" API notes are waiting on Cal's team / CCC-301 — don't propose implementing those APIs from this repo.
+- **Plugin source is source-of-truth.** SKILL.md files are both the plan AND the docs. `/ace:docs` regenerates `docs/generated/playbook.md` from them.
+- **Don't touch ace-web from this repo.** It's a separate GitHub repo; the submodule was removed in favor of a README link.
+- **LLM-as-Judge runs inside skills** — skills self-evaluate before the next step. Criteria live in each SKILL.md.
+- **Regression risk is real.** ACE sends emails, publishes apps, creates Jira tickets. SKILL.md edits should be re-tested against CRISPR-Test-001 before live runs.

--- a/.claude/pm/learnings.md
+++ b/.claude/pm/learnings.md
@@ -1,0 +1,9 @@
+# Product Management Learnings
+
+Items closed or rejected during PM cycles. Read this before every scout run to avoid re-proposing.
+
+## Closed Items
+(none yet)
+
+## Preferences
+(none yet)

--- a/.claude/pm/runs/2026-04-08-focus-group-framework.md
+++ b/.claude/pm/runs/2026-04-08-focus-group-framework.md
@@ -1,0 +1,77 @@
+## 2026-04-08 — focus-group-framework (custom lens)
+
+**Lens used:** `improved skill framework so we can run focus groups, see docs folder for background ideas` (custom — not one of the standard rotation lenses).
+
+**Background read:** `README.md`, `docs/superpowers/specs/2026-04-01-ace-design.md`, `docs/generated/playbook.md`, `docs/examples/idd-vaccine-hesitancy.md`, `docs/examples/idd-turmeric-market-survey.md`, `docs/examples/idd-stress-test-observations.md`, `templates/idd-template.md`, and the SKILL.md files for `idea-to-idd`, `idd-to-learn-app`, `idd-to-deliver-app`, `app-test`, `connect-opp-setup`, `flw-data-review`, `cycle-grade`. Also confirmed PR #3 added the example IDDs.
+
+**Core finding:** every existing skill is hard-coded to one delivery archetype — "one FLW visit = one photo + GPS + form." Never named as an assumption; baked into the IDD template, the section list in `idea-to-idd`, the Nova briefs, the verification vocabulary in `connect-opp-setup`, the quantitative queries in `flw-data-review`, and the grading dimensions in `cycle-grade`. A focus-group IDD walks in and silently breaks. The fix is **not** "add 4 new focus-group skills" (the stress-test doc's suggestion) — that forks the framework. The fix is to give skills variation points that branch on a declared archetype, plus a shared evidence-model vocabulary.
+
+### Do it
+
+1. **F2 — Stress-test rubric in `idea-to-idd`** — Effort: S — Status: **done, merged into PR #4**
+   - Branch: `emdash/pm-session-9n4`
+   - PR: jjackson/ace#4
+   - Outcome: 5-question rubric (executability, verifiability, measurability, stage-gate clarity, resource realism) replaces the weak "is it complete enough" self-eval. Includes vaccine-hesitancy and turmeric IDDs as calibrated grading anchors. Stress-test results emitted as IDD appendix.
+
+2. **F1 — Delivery archetype as first-class concept** — Effort: M — Status: **done, in PR #4**
+   - Branch: `emdash/pm-session-9n4`
+   - PR: jjackson/ace#4
+   - Outcome: New `Archetype:` field in `templates/idd-template.md` (atomic-visit | focus-group | multi-stage). `## Archetypes` section added to all 7 archetype-aware skills with concrete focus-group branches drawn from the stress-test doc and the vaccine-hesitancy IDD. atomic-visit is the default; new archetypes are additive PRs.
+
+3. **F3 — Evidence Model section + downstream consumption** — Effort: M — Status: **done, in PR #4**
+   - Branch: `emdash/pm-session-9n4`
+   - PR: jjackson/ace#4
+   - Outcome: New `## Evidence Model` section in IDD template using Layer A (delivery proof) / Layer B (content proof) / Layer C (cross-delivery quality) vocabulary. `connect-opp-setup`, `app-test`, `flw-data-review`, `cycle-grade` now read from this section instead of re-deriving verification. Skills error if Evidence Model is missing.
+
+4. **F4 — CRISPR-Test-002 focus-group fixture** — Effort: M — Status: **done, in PR #4**
+   - Branch: `emdash/pm-session-9n4`
+   - PR: jjackson/ace#4
+   - Outcome: Pair fixture to CRISPR-Test-001 (atomic-visit). Simplified vaccine-hesitancy IDD (Stage 1 only, 2 segments, 1 LLO), full Evidence Model, stress-test all-pass. README.md documents the regression spec for each archetype-aware skill against the fixture. Stub Learn + Deliver app summaries.
+
+### Backlog
+
+(none from this run — all 4 proposals were dispositioned "Do it" and shipped together)
+
+### Closed
+
+(none from this run — no proposals were rejected)
+
+### Skipped on this run (raised but not formally proposed)
+
+- **F5 — `skills/README.md` author contract**. Not yet urgent; would document required SKILL.md sections (frontmatter, Process, MCP Tools Used, Mode Behavior, Dry-Run Behavior, Change Log) plus optional Archetypes / LLM-as-Judge Rubric / Evidence Model. Natural follow-on once a third archetype or a non-Jon contributor starts touching skills. Hold for a future cycle's `tech-debt` lens.
+- **Regenerate `docs/generated/playbook.md`**. `/ace:docs` is a slash command, not a script — it must be run by Claude. Noted in PR description as a post-merge step. Could become a hook (`afterMerge` for skills/ changes).
+- **Add `archetype: atomic-visit` to CRISPR-Test-001's IDD**. Currently relies on the default fallback. Adding it explicitly would let the fixture demonstrate the new field. Trivial follow-up; not in this PR to keep the diff focused.
+
+### Meta-observations
+
+**What worked well:**
+- Doing the docs read in parallel (Bash + Glob + Read in batched calls) was much faster than sequential. I read 7 files in 2 message turns.
+- Bootstrapping `context.md` from the existing README + design spec + memory rather than asking 4 questions interactively saved a lot of round-trips. The skill explicitly allows skipping questions answerable from code — that flexibility was the right call here.
+- The lens being a custom string (not one of the rotation 5) wasn't a problem. The skill's framing of "exploration lenses" as suggestive rather than prescriptive worked well — I just used the user's exact phrasing.
+- The stress-test doc (`docs/examples/idd-stress-test-observations.md`) was load-bearing background. Without it I would have proposed a much weaker version of F2/F3, because that doc had already done the conceptual work — I was mostly formalizing what was already a one-off observation into framework-level structure.
+- Using `AskUserQuestion` for per-proposal disposition kept the user in control without ambiguous bulk-chat answers. All 4 dispositions came through cleanly.
+
+**What was wasteful:**
+- I made one duplicate-numbering mistake in the ordered list in `idea-to-idd/SKILL.md` (had two "step 4"s after the initial Edit) and had to do a follow-up renumber. Checking step numbering after each big ordered-list edit would have caught it inline.
+- Same again in `app-test/SKILL.md` — needed a follow-up renumber after adding step 3. Pattern: any time I insert a step in the middle of an ordered list, I should grep `^[0-9]+\.` immediately after to verify sequential numbering.
+- I read the focus-group example IDD twice — once to extract focus-group structure, once when checking the stress-test doc that links to it. Would have been fine to skip the second read.
+- I checked `.gitignore` and `.claude/` tracking *after* writing files to `.claude/pm/` rather than before. Result was correct (those files stayed untracked, which was the right choice), but I could have established the rule before writing.
+
+**Prompt adjustments for next time:**
+- For multi-skill framework changes like this one, the right number of proposals is 3–4, not the standard 3. The user dispositioned all 4 as "Do it" because they were tightly interdependent — splitting the 4 across two cycles would have shipped half a feature. The skill's "top 3" guidance is a soft cap, not a rule.
+- When the user asks for a "framework" change, the wrong instinct is to add new skills/files. The right instinct is to add variation points to existing skills/files. I need to keep that as a working bias for any future "framework" lens.
+- The `## Archetypes` section pattern (default + branches, declared once per skill) is reusable for *any* configuration that varies across IDD types. If a future cycle introduces something like `## Modalities` (online vs in-person) or `## Geographies` (regulatory branching), the same pattern should be considered before forking skills.
+
+**Confidence on validation:**
+- Medium-high. F1, F3, F4 are well-instrumented in the SKILL.md text and the fixture has explicit pass/fail expectations per skill. Real validation requires running the skills against the fixture in a Claude session, which I can't do from the implementing session without round-tripping through the user. The test plan in PR #4 makes this explicit.
+- Lower on F2 specifically — LLM-as-Judge rubrics are notoriously generous. The few-shot grading anchors (vaccine-hesitancy-as-fail, turmeric-as-near-pass) help, but the proof comes from running it. If the rubric grades the vaccine-hesitancy IDD as "pass" or grades the turmeric IDD as "fail," that's a false positive that needs the rubric tightened.
+
+### Self-improvement (canopy-skills meta-PRs)
+
+Three universal-improvement candidates surfaced from this run's meta-observations were proposed as PRs against `jjackson/canopy-skills`:
+
+1. **U1 — Custom lens support is first-class.** jjackson/canopy-skills#7. Adds a one-paragraph note to Phase 1 clarifying that custom lenses (not in the rotation list) are first-class. Two-line addition; no existing content removed.
+2. **U2 — Top-N can exceed 3 when interdependent.** jjackson/canopy-skills#8. Softens Phase 2's "top 3" hard cap to a soft default with an explicit interdependence escape hatch. One-line edit.
+3. **U3 — Lesson #9: Framework changes mean variation points, not new components.** jjackson/canopy-skills#9. Appends a 9th lesson encoding the parameterization-over-fork bias for "framework" lenses.
+
+All three PRs are open for jjackson review. Per the Self-Improvement Protocol, the skill is intentionally gated on human review before merging — no auto-merge.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 # Temporary scripts and artifacts from live-OCS verification sessions.
 # These contain exploration code and HTML dumps that shouldn't live in git.
 scripts/tmp/
+
+# Claude Code session-local settings (per-developer, not shared state)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Fixes an oversight from earlier in this session. The product-management skill's whole design relies on \`.claude/pm/\` persisting across sessions — \`context.md\` (what this project is), \`learnings.md\` (closed/rejected items), \`runs/\` (per-cycle logs). Earlier I marked \`.claude/pm/\` as \"intentionally not tracked\" on the incorrect assumption that \`.claude/\` was globally git-ignored. In fact only \`.claude/settings.local.json\` is ignored (via \`**/.claude/settings.local.json\` in the global gitignore). The rest of \`.claude/\` is fair game.

Without this PR, a fresh clone or a fresh worktree starting a PM cycle would have no history and would re-bootstrap \`context.md\` from scratch, potentially re-propose closed items, and lose the run log from the focus-group framework cycle.

## What's being committed

- \`.claude/pm/context.md\` — ACE product context (what it is, who uses it, what matters, tech stack, current state, known considerations). Bootstrapped during the 2026-04-08 focus-group framework cycle from the README + design spec + memory.
- \`.claude/pm/learnings.md\` — empty (no closed items from this cycle, but the file needs to exist so future cycles have somewhere to write)
- \`.claude/pm/runs/2026-04-08-focus-group-framework.md\` — the run log from the focus-group framework cycle: scout findings, 4 proposals (F1–F4), all dispositions, implementation status, meta-observations, and the self-improvement proposals that became canopy-skills#7/#8/#9.

## Also in this PR

- \`.gitignore\` — added \`.claude/settings.local.json\` as an explicit project-level ignore. That file is already covered by the global ignore pattern (\`**/.claude/settings.local.json\`), but making it explicit at the project level protects contributors who don't share the same global config. They'd otherwise accidentally commit their per-developer session settings on a fresh clone.

## Why this matters

The canopy \`product-management\` skill (which drove this session) explicitly documents that \`.claude/pm/\` is the skill's **memory** across sessions:

> Every run: Read \`context.md\` and \`learnings.md\` before doing anything else. These are your memory.

If the files only exist on one developer's machine, the \"feed closed items into future runs\" guarantee breaks. Lesson 7 of the skill (*\"Feed closed items into future runs\"*) can only hold if the closed-item history is tracked in git.

## Test plan

- [ ] Verify \`git check-ignore -v .claude/pm/context.md\` returns no match (file is not ignored)
- [ ] Verify \`git check-ignore -v .claude/settings.local.json\` returns a match (file is still ignored)
- [ ] Pull a fresh clone on a different machine and confirm \`.claude/pm/\` is present with the three files
- [ ] Next PM scout cycle should read \`context.md\` and \`learnings.md\` without needing to re-bootstrap

## Related

- Fixes an oversight from #5's test plan notes (\"\`.claude/pm/\` PM state is intentionally not tracked\" — this was wrong)
- Complements the \`skills/README.md\` author contract from #5, which implicitly assumes PM state persists across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)