### PR TITLE
fix(doctor): align warn/fail helpers with 2-arg call sites

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -42,8 +42,8 @@ fi
 echo "INFO plugin_root=$ROOT"
 
 pass() { echo "PASS $1"; }
-warn() { echo "WARN $1: $2"; [ -n "${3:-}" ] && echo "  fix: $3"; }
-fail() { echo "FAIL $1: $2"; [ -n "${3:-}" ] && echo "  fix: $3"; }
+warn() { echo "WARN $1"; [ -n "${2:-}" ] && echo "  fix: $2"; }
+fail() { echo "FAIL $1"; [ -n "${2:-}" ] && echo "  fix: $2"; }
 
 # --- Version consistency ---
 VER_FILE="$(tr -d "[:space:]" < "$ROOT/VERSION" 2>/dev/null || echo missing)"


### PR DESCRIPTION
Small follow-up to #11. The `warn()` and `fail()` helpers in `commands/doctor.md` were declared to take three arguments (name, message, hint) but every call site passes two. Result: the `  fix: ...` line never printed and the hint got concatenated onto the message line with a stray `:`.

Caught by running the doctor bash block against a local worktree after #11 merged.

**Before:**
```
FAIL gws_key: missing at .../.gws-sa-key.json: drop your Google service-account JSON at this path (ask Jon for the Dimagi key)
WARN auto_update: not registered: run /ace:setup --auto-update to enable background update checks
```

**After:**
```
FAIL gws_key: missing at .../.gws-sa-key.json
  fix: drop your Google service-account JSON at this path (ask Jon for the Dimagi key)
WARN auto_update: not registered
  fix: run /ace:setup --auto-update to enable background update checks
```

## Test plan

- [x] Ran the patched bash block — both FAIL and WARN now print the indented fix hint as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)