### PR TITLE
fix(mcp): Shared Drive support + GOOGLE_APPLICATION_CREDENTIALS-based SA key

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,10 @@
 {
   "ace-gdrive": {
     "command": "npx",
-    "args": ["tsx", "${CLAUDE_PLUGIN_ROOT}/mcp/google-drive-server.ts"]
+    "args": ["tsx", "${CLAUDE_PLUGIN_ROOT}/mcp/google-drive-server.ts"],
+    "env": {
+      "GOOGLE_APPLICATION_CREDENTIALS": "${CLAUDE_PLUGIN_DATA}/gws-sa-key.json"
+    }
   },
   "ace-ocs": {
     "command": "npx",

--- a/README.md
+++ b/README.md
@@ -41,20 +41,33 @@ that runs background update checks.
 
 The one thing `/ace:setup` can't do for you is drop in the service-account
 key — it's a secret you have to supply. When the setup script reports
-`GWS_KEY: MISSING`, it will print the exact path. Copy your key there:
+`GWS_KEY: MISSING`, it prints the canonical path (under `$CLAUDE_PLUGIN_DATA`)
+and the exact `mkdir -p … && mv … && chmod 600 …` command to run. That
+location is persistent across plugin updates and shared by every worktree and
+install, so you only drop the key once per machine.
 
-```bash
-cp /path/to/your/sa-key.json <path-from-setup-output>/.gws-sa-key.json
-```
+The `.mcp.json` passes the path to the MCP server via the standard
+`GOOGLE_APPLICATION_CREDENTIALS` env var, expanded from
+`${CLAUDE_PLUGIN_DATA}/gws-sa-key.json` at server launch.
 
-The service account needs `https://www.googleapis.com/auth/spreadsheets` and
-`https://www.googleapis.com/auth/drive` scopes. The Dimagi service account
-currently used is
-`gws-local-dev@dimagi-chrome-extension.iam.gserviceaccount.com` — ask Jon for
-the key.
+The service account needs `https://www.googleapis.com/auth/spreadsheets`,
+`https://www.googleapis.com/auth/drive`, and
+`https://www.googleapis.com/auth/documents` scopes. The ACE service account is
+`ace-service-account@connect-labs.iam.gserviceaccount.com` — ask Jon for the
+key. It must be added as Editor on the ACE folder inside the Shared Drive for
+artifact creation to work; see the "Shared Drive" note below.
 
-After dropping the key, re-run `/ace:setup` and then restart your Claude Code
-session. The `ace-gdrive` MCP server should appear in `/mcp`.
+After dropping the key, re-run `/ace:setup` and then `/reload-plugins`. The
+`ace-gdrive` MCP server should appear in `/mcp`.
+
+#### Shared Drive requirement
+
+ACE skills create Google Docs inside an ACE folder that **must live in a
+Google Shared Drive**, not in anyone's "My Drive". Service accounts have zero
+personal Drive storage quota, so creating files under a My Drive folder fails
+with `Service Accounts do not have storage quota`. Inside a Shared Drive the
+Drive itself owns the files, and the SA only needs Editor permission on the
+target folder.
 
 ### Verify
 
@@ -73,9 +86,11 @@ MCP manifest, and related repos (`ace-web`, `connect-labs`). Prints PASS / WARN
 ```
 
 Pulls the latest release from `~/.claude/plugins/marketplaces/ace`, copies it
-into a new versioned cache dir (carrying forward your `.gws-sa-key.json`),
-reinstalls deps, updates `installed_plugins.json`, and tells you to
-`/reload-plugins`. See [CHANGELOG.md](CHANGELOG.md) for release notes.
+into a new versioned cache dir, reinstalls deps, updates
+`installed_plugins.json`, and tells you to `/reload-plugins`. Your
+service-account key lives in `$CLAUDE_PLUGIN_DATA`, which is outside the
+versioned cache dir, so it automatically carries forward without any special
+handling. See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 If you'd rather not run this by hand, `/ace:setup --auto-update` registers a
 `SessionStart` hook that checks for new versions in the background every

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -78,16 +78,38 @@ else
 fi
 
 # --- Google service-account key ---
-KEY="$ROOT/.gws-sa-key.json"
-if [ -f "$KEY" ] && [ -r "$KEY" ]; then
+# Canonical location: $CLAUDE_PLUGIN_DATA/gws-sa-key.json (persistent across
+# plugin updates). Falls back to the legacy in-repo path for pre-migration
+# installs. Claude Code expands ${CLAUDE_PLUGIN_DATA} in .mcp.json at server
+# launch, so the canonical path must exist whenever the plugin is installed
+# from a marketplace.
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  DATA_DIR="$CLAUDE_PLUGIN_DATA"
+else
+  DATA_DIR="$HOME/.claude/plugins/data/ace-ace"
+fi
+CANONICAL_KEY="$DATA_DIR/gws-sa-key.json"
+LEGACY_KEY="$ROOT/.gws-sa-key.json"
+
+KEY=""
+KEY_LOC=""
+if [ -f "$CANONICAL_KEY" ] && [ -r "$CANONICAL_KEY" ]; then
+  KEY="$CANONICAL_KEY"; KEY_LOC="canonical"
+elif [ -f "$LEGACY_KEY" ] && [ -r "$LEGACY_KEY" ]; then
+  KEY="$LEGACY_KEY"; KEY_LOC="legacy"
+fi
+
+if [ -n "$KEY" ]; then
   CE="$(node -e "try { console.log(JSON.parse(require(\"fs\").readFileSync(\"$KEY\",\"utf8\")).client_email); } catch(e) { console.log(\"unreadable\"); }" 2>/dev/null || echo unreadable)"
   if [ "$CE" = "unreadable" ]; then
     fail "gws_key: $KEY is not valid JSON" "re-drop the service-account key"
+  elif [ "$KEY_LOC" = "legacy" ]; then
+    warn "gws_key: $CE at LEGACY path $LEGACY_KEY" "migrate to $CANONICAL_KEY so it survives plugin updates: mv \"$LEGACY_KEY\" \"$CANONICAL_KEY\" && chmod 600 \"$CANONICAL_KEY\""
   else
-    pass "gws_key: $CE"
+    pass "gws_key: $CE at $CANONICAL_KEY"
   fi
 else
-  fail "gws_key: missing at $KEY" "drop your Google service-account JSON at this path (ask Jon for the Dimagi key)"
+  fail "gws_key: missing (checked $CANONICAL_KEY and $LEGACY_KEY)" "mkdir -p \"$DATA_DIR\" && drop the service-account JSON at $CANONICAL_KEY (ask Jon for the ACE key)"
 fi
 
 # --- .mcp.json sanity ---

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -87,13 +87,38 @@ else
 fi
 
 # --- Check for the Google service-account key ---
-KEY_PATH="$ROOT/.gws-sa-key.json"
-if [ -f "$KEY_PATH" ] && [ -r "$KEY_PATH" ]; then
-  # Parse client_email to show *which* service account is wired up
-  CLIENT_EMAIL="$(node -e "try { console.log(JSON.parse(require(\"fs\").readFileSync(\"$KEY_PATH\",\"utf8\")).client_email); } catch(e) { console.log(\"unreadable\"); }" 2>/dev/null || echo "unreadable")"
-  echo "GWS_KEY: ok ($CLIENT_EMAIL)"
+# Preferred location: $CLAUDE_PLUGIN_DATA/gws-sa-key.json — persistent across
+# plugin updates and shared across worktrees. Claude Code sets
+# $CLAUDE_PLUGIN_DATA when the plugin is loaded; if this script is run from a
+# bare checkout we compute the canonical path the same way Claude Code would
+# (~/.claude/plugins/data/<plugin>-<marketplace>/).
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  DATA_DIR="$CLAUDE_PLUGIN_DATA"
 else
-  echo "GWS_KEY: MISSING — drop your service-account JSON at $KEY_PATH"
+  DATA_DIR="$HOME/.claude/plugins/data/ace-ace"
+fi
+mkdir -p "$DATA_DIR"
+CANONICAL_KEY="$DATA_DIR/gws-sa-key.json"
+LEGACY_KEY="$ROOT/.gws-sa-key.json"
+
+KEY_PATH=""
+if [ -f "$CANONICAL_KEY" ] && [ -r "$CANONICAL_KEY" ]; then
+  KEY_PATH="$CANONICAL_KEY"
+elif [ -f "$LEGACY_KEY" ] && [ -r "$LEGACY_KEY" ]; then
+  KEY_PATH="$LEGACY_KEY"
+fi
+
+if [ -n "$KEY_PATH" ]; then
+  CLIENT_EMAIL="$(node -e "try { console.log(JSON.parse(require(\"fs\").readFileSync(\"$KEY_PATH\",\"utf8\")).client_email); } catch(e) { console.log(\"unreadable\"); }" 2>/dev/null || echo "unreadable")"
+  if [ "$KEY_PATH" = "$CANONICAL_KEY" ]; then
+    echo "GWS_KEY: ok ($CLIENT_EMAIL) at canonical $CANONICAL_KEY"
+  else
+    echo "GWS_KEY: ok ($CLIENT_EMAIL) at LEGACY path $LEGACY_KEY"
+    echo "GWS_KEY_MIGRATE: move to $CANONICAL_KEY so it survives plugin updates"
+  fi
+else
+  echo "GWS_KEY: MISSING — drop your service-account JSON at $CANONICAL_KEY"
+  echo "GWS_KEY_HINT: mkdir -p \"$DATA_DIR\" && mv /path/to/key.json \"$CANONICAL_KEY\" && chmod 600 \"$CANONICAL_KEY\""
 fi
 
 # --- Check .mcp.json ---
@@ -124,7 +149,8 @@ Read the output line-by-line:
 - `STATUS: OK` — Setup succeeded. Continue to Step 3.
 - `STATUS: ERROR plugin_root_not_found` — Tell the user the plugin root couldn't be found. Ask them to run this from inside a Claude Code session that has ACE installed, or from their local ACE checkout. **STOP.**
 - `STATUS: ERROR node_missing` or `npm_missing` — Tell the user to install Node.js (v18+). **STOP.**
-- `GWS_KEY: MISSING …` — Include the exact path in your message and tell the user: "Drop your Google service-account JSON at `<path>`. Ask Jon for the Dimagi key if you don't have one (service account: `gws-local-dev@dimagi-chrome-extension.iam.gserviceaccount.com`)."
+- `GWS_KEY: MISSING …` — Include the exact path in your message and tell the user: "Drop your Google service-account JSON at `<path>` (use the `GWS_KEY_HINT` command to create the dir and chmod the file). Ask Jon for the ACE key if you don't have one (service account: `ace-service-account@connect-labs.iam.gserviceaccount.com`)."
+- `GWS_KEY: ok … at LEGACY path …` — The key still works but lives in the plugin checkout dir, which gets wiped on plugin updates. Show the user the `GWS_KEY_MIGRATE` line and offer to move it: `mv <legacy> <canonical> && chmod 600 <canonical>`.
 - `TSX: missing` or `INSTALL_STATUS` nonzero — Tell the user `npm install` failed; show the last ~20 lines of output and ask them to fix the underlying npm error.
 - `VERSION: MISMATCH` — Warn the user and tell them to open an issue; this should never happen in a clean install.
 

--- a/commands/update.md
+++ b/commands/update.md
@@ -65,20 +65,12 @@ Run this single bash command. Replace `NEW_VERSION` with the version from Step 1
 
 ```bash
 NEW_VERSION=<version from step 1> && \
-OLD_CACHE="$(ls -1dt ~/.claude/plugins/cache/ace/ace/* 2>/dev/null | head -1)" && \
 mkdir -p ~/.claude/plugins/cache/ace/ace/$NEW_VERSION && \
 rsync -a --delete \
   --exclude='node_modules' \
-  --exclude='.gws-sa-key.json' \
   --exclude='.git' \
   ~/.claude/plugins/marketplaces/ace/ \
   ~/.claude/plugins/cache/ace/ace/$NEW_VERSION/ && \
-if [ -n "$OLD_CACHE" ] && [ -f "$OLD_CACHE/.gws-sa-key.json" ]; then \
-  cp "$OLD_CACHE/.gws-sa-key.json" ~/.claude/plugins/cache/ace/ace/$NEW_VERSION/.gws-sa-key.json && \
-  echo "KEY: carried forward from $OLD_CACHE"; \
-else \
-  echo "KEY: no previous key found — run /ace:setup after this to drop it in"; \
-fi && \
 cd ~/.claude/plugins/cache/ace/ace/$NEW_VERSION && \
 echo "INSTALLING: npm install (may take 30-60s)" && \
 npm install --silent 2>&1 | tail -10 && \
@@ -148,6 +140,7 @@ Summarize the top entry in 3-5 bullets.
   `~/emdash-projects/ace` or dev worktree.
 - If Step 1 says `UP_TO_DATE`, STOP immediately. Do not run Step 2.
 - Always tell the user to run `/reload-plugins` after a successful update.
-- The `.gws-sa-key.json` and `node_modules/` are deliberately excluded from the
-  rsync: the key is carried forward explicitly, and `node_modules` is
-  reinstalled fresh against the new `package.json`.
+- `node_modules/` is deliberately excluded from the rsync so it's reinstalled
+  fresh against the new `package.json`. The service-account key lives in
+  `$CLAUDE_PLUGIN_DATA` (outside the versioned cache dir) so it automatically
+  survives updates without any explicit copy-forward.

--- a/docs/superpowers/specs/2026-04-01-ace-design.md
+++ b/docs/superpowers/specs/2026-04-01-ace-design.md
@@ -133,7 +133,7 @@ Each skill is a SKILL.md file that handles one step of the CRISPR-Connect proces
 ### MCP Servers
 
 **In ACE repo:**
-- **Google Drive MCP** (`mcp/google-drive-server.ts`) — Sheets + Drive tools. Already built. Service account: `gws-local-dev@dimagi-chrome-extension.iam.gserviceaccount.com`. This is the canonical Google Drive MCP, registered in canopy's registry for cross-project use.
+- **Google Drive MCP** (`mcp/google-drive-server.ts`) — Sheets + Drive tools. Already built. Service account: `ace-service-account@connect-labs.iam.gserviceaccount.com`. The SA key is resolved via `GOOGLE_APPLICATION_CREDENTIALS`, which `.mcp.json` sets to `${CLAUDE_PLUGIN_DATA}/gws-sa-key.json` so it persists across plugin updates and is shared across all worktrees/installs. This is the canonical Google Drive MCP, registered in canopy's registry for cross-project use.
 - **OCS MCP** (`mcp/ocs-server.ts`) — To build. Agent management (create/configure agents per opportunity), transcript access (read LLO conversations for analysis), context injection.
 
 **In connect-labs (external):**

--- a/mcp/google-drive-server.ts
+++ b/mcp/google-drive-server.ts
@@ -234,6 +234,8 @@ server.tool(
         q: `'${folderId}' in parents and trashed = false`,
         fields: 'files(id, name, mimeType, modifiedTime, webViewLink)',
         orderBy: 'name',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
       return result(resp.data.files);
     } catch (e: any) {
@@ -251,7 +253,7 @@ server.tool(
   },
   async ({ fileId }) => {
     try {
-      const meta = await drive.files.get({ fileId, fields: 'mimeType, name' });
+      const meta = await drive.files.get({ fileId, fields: 'mimeType, name', supportsAllDrives: true });
       const mimeType = meta.data.mimeType || '';
 
       let content: string;
@@ -259,7 +261,7 @@ server.tool(
         const resp = await drive.files.export({ fileId, mimeType: 'text/plain' }, { responseType: 'text' });
         content = resp.data as string;
       } else {
-        const resp = await drive.files.get({ fileId, alt: 'media' }, { responseType: 'text' });
+        const resp = await drive.files.get({ fileId, alt: 'media', supportsAllDrives: true }, { responseType: 'text' });
         content = resp.data as string;
       }
 
@@ -284,6 +286,7 @@ server.tool(
         fileId,
         media: { mimeType: 'text/plain', body: newContent },
         fields: 'id, name, modifiedTime',
+        supportsAllDrives: true,
       });
       return result({ id: resp.data.id, name: resp.data.name, modifiedTime: resp.data.modifiedTime });
     } catch (e: any) {
@@ -313,6 +316,7 @@ server.tool(
       const created = await drive.files.create({
         requestBody: fileMetadata,
         fields: 'id, name, webViewLink',
+        supportsAllDrives: true,
       });
       const fileId = created.data.id!;
 
@@ -320,6 +324,7 @@ server.tool(
         fileId,
         media: { mimeType: 'text/plain', body: fileContent },
         fields: 'id',
+        supportsAllDrives: true,
       });
 
       return result({ id: fileId, name: created.data.name, webViewLink: created.data.webViewLink });
@@ -349,6 +354,7 @@ server.tool(
       const resp = await drive.files.create({
         requestBody: fileMetadata,
         fields: 'id, name, webViewLink',
+        supportsAllDrives: true,
       });
       return result({ id: resp.data.id, name: resp.data.name, webViewLink: resp.data.webViewLink });
     } catch (e: any) {
@@ -367,7 +373,7 @@ server.tool(
   },
   async ({ fileId, newParentFolderId }) => {
     try {
-      const file = await drive.files.get({ fileId, fields: 'parents' });
+      const file = await drive.files.get({ fileId, fields: 'parents', supportsAllDrives: true });
       const previousParents = (file.data.parents || []).join(',');
 
       const resp = await drive.files.update({
@@ -375,6 +381,7 @@ server.tool(
         addParents: newParentFolderId,
         removeParents: previousParents,
         fields: 'id, name, parents, webViewLink',
+        supportsAllDrives: true,
       });
       return result({ id: resp.data.id, name: resp.data.name, webViewLink: resp.data.webViewLink });
     } catch (e: any) {
@@ -396,6 +403,7 @@ server.tool(
       const resp = await drive.permissions.create({
         fileId,
         transferOwnership: true,
+        supportsAllDrives: true,
         requestBody: {
           type: 'user',
           role: 'owner',
@@ -433,6 +441,8 @@ server.tool(
           pageSize: 10,
           fields: 'files(id, name, mimeType, owners, shared)',
           orderBy: 'modifiedTime desc',
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
         });
         results.visibleFiles = list.data.files?.map(f => ({
           name: f.name,
@@ -445,7 +455,7 @@ server.tool(
 
       if (testFileId) {
         try {
-          const file = await drive.files.get({ fileId: testFileId, fields: 'id, name, mimeType, owners, permissions' });
+          const file = await drive.files.get({ fileId: testFileId, fields: 'id, name, mimeType, owners, permissions', supportsAllDrives: true });
           results.testFile = { name: file.data.name, mimeType: file.data.mimeType };
         } catch (e: any) {
           results.testFile = `FAILED: ${e.message}`;
@@ -534,6 +544,7 @@ server.tool(
         fileId: templateDocId,
         requestBody: copyMetadata,
         fields: 'id, name, webViewLink',
+        supportsAllDrives: true,
       });
       const newDocId = copy.data.id!;
 

--- a/mcp/google-drive-server.ts
+++ b/mcp/google-drive-server.ts
@@ -16,21 +16,47 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const SA_KEY_PATH = path.join(PROJECT_ROOT, '.gws-sa-key.json');
+const LEGACY_KEY_PATH = path.join(PROJECT_ROOT, '.gws-sa-key.json');
+
+const SCOPES = [
+  'https://www.googleapis.com/auth/spreadsheets',
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/documents',
+];
 
 // ============================================================================
 // Auth
 // ============================================================================
 
+/**
+ * Resolve the Google service-account key path.
+ *
+ * Priority:
+ *   1. $GOOGLE_APPLICATION_CREDENTIALS — Google's standard env var. In .mcp.json
+ *      we set this to ${CLAUDE_PLUGIN_DATA}/gws-sa-key.json so Claude Code expands
+ *      it to the per-plugin persistent data dir at launch (survives plugin updates
+ *      and is shared across worktrees / installed copies).
+ *   2. <plugin-root>/.gws-sa-key.json — legacy fallback so existing local dev
+ *      checkouts and pre-migration installs keep working.
+ */
+function resolveKeyPath(): string {
+  const envPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (envPath && fs.existsSync(envPath)) {
+    return envPath;
+  }
+  if (fs.existsSync(LEGACY_KEY_PATH)) {
+    return LEGACY_KEY_PATH;
+  }
+  throw new Error(
+    `No Google service-account key found. Set GOOGLE_APPLICATION_CREDENTIALS ` +
+      `or place the key at ${LEGACY_KEY_PATH}. Run /ace:setup for help.`,
+  );
+}
+
 function getAuth() {
-  const keyFile = JSON.parse(fs.readFileSync(SA_KEY_PATH, 'utf-8'));
   return new google.auth.GoogleAuth({
-    credentials: keyFile,
-    scopes: [
-      'https://www.googleapis.com/auth/spreadsheets',
-      'https://www.googleapis.com/auth/drive',
-      'https://www.googleapis.com/auth/documents',
-    ],
+    keyFile: resolveKeyPath(),
+    scopes: SCOPES,
   });
 }
 

--- a/scripts/test-sa-create.ts
+++ b/scripts/test-sa-create.ts
@@ -1,8 +1,14 @@
 /**
  * Throwaway test: verify the ACE service account can create + update + delete
- * a doc inside the target ACE folder. Run with:
+ * a doc inside the target ACE folder. Mirrors the key resolution logic from
+ * mcp/google-drive-server.ts so this script also validates the
+ * GOOGLE_APPLICATION_CREDENTIALS env var code path. Run with:
  *
+ *   # fallback path (in-repo key):
  *   npx tsx scripts/test-sa-create.ts
+ *
+ *   # canonical env-var path:
+ *   GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json npx tsx scripts/test-sa-create.ts
  */
 import { google } from 'googleapis';
 import fs from 'fs';
@@ -10,15 +16,31 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const SA_KEY_PATH = path.join(PROJECT_ROOT, '.gws-sa-key.json');
+const LEGACY_KEY_PATH = path.join(PROJECT_ROOT, '.gws-sa-key.json');
 const TARGET_FOLDER_ID = '1HThsA_0Lr5p1OdI5r-aQ446HlNBaySLz';
 
+function resolveKeyPath(): { path: string; source: 'env' | 'legacy' } {
+  const envPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (envPath && fs.existsSync(envPath)) {
+    return { path: envPath, source: 'env' };
+  }
+  if (fs.existsSync(LEGACY_KEY_PATH)) {
+    return { path: LEGACY_KEY_PATH, source: 'legacy' };
+  }
+  throw new Error(
+    `No SA key found. Set GOOGLE_APPLICATION_CREDENTIALS or drop key at ${LEGACY_KEY_PATH}`,
+  );
+}
+
 async function main() {
-  const keyFile = JSON.parse(fs.readFileSync(SA_KEY_PATH, 'utf-8'));
-  console.log('SA email:', keyFile.client_email);
+  const key = resolveKeyPath();
+  console.log(`Key source: ${key.source}`);
+  console.log(`Key path:   ${key.path}`);
+  const keyFile = JSON.parse(fs.readFileSync(key.path, 'utf-8'));
+  console.log(`SA email:   ${keyFile.client_email}`);
 
   const auth = new google.auth.GoogleAuth({
-    credentials: keyFile,
+    keyFile: key.path,
     scopes: [
       'https://www.googleapis.com/auth/drive',
       'https://www.googleapis.com/auth/documents',

--- a/scripts/test-sa-create.ts
+++ b/scripts/test-sa-create.ts
@@ -1,0 +1,82 @@
+/**
+ * Throwaway test: verify the ACE service account can create + update + delete
+ * a doc inside the target ACE folder. Run with:
+ *
+ *   npx tsx scripts/test-sa-create.ts
+ */
+import { google } from 'googleapis';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SA_KEY_PATH = path.join(PROJECT_ROOT, '.gws-sa-key.json');
+const TARGET_FOLDER_ID = '1HThsA_0Lr5p1OdI5r-aQ446HlNBaySLz';
+
+async function main() {
+  const keyFile = JSON.parse(fs.readFileSync(SA_KEY_PATH, 'utf-8'));
+  console.log('SA email:', keyFile.client_email);
+
+  const auth = new google.auth.GoogleAuth({
+    credentials: keyFile,
+    scopes: [
+      'https://www.googleapis.com/auth/drive',
+      'https://www.googleapis.com/auth/documents',
+    ],
+  });
+  const drive = google.drive({ version: 'v3', auth });
+
+  // Step 1: can we see the target folder at all?
+  console.log('\n[1] get target folder metadata...');
+  const folder = await drive.files.get({
+    fileId: TARGET_FOLDER_ID,
+    fields: 'id, name, mimeType, driveId, parents',
+    supportsAllDrives: true,
+  });
+  console.log('    name:', folder.data.name);
+  console.log('    driveId (shared drive):', folder.data.driveId ?? '(none — this is My Drive!)');
+
+  // Step 2: create a Google Doc inside it.
+  console.log('\n[2] create Google Doc in folder...');
+  const created = await drive.files.create({
+    requestBody: {
+      name: `ACE SA smoke test ${new Date().toISOString()}`,
+      mimeType: 'application/vnd.google-apps.document',
+      parents: [TARGET_FOLDER_ID],
+    },
+    fields: 'id, name, webViewLink, driveId, parents',
+    supportsAllDrives: true,
+  });
+  const fileId = created.data.id!;
+  console.log('    created id:', fileId);
+  console.log('    name:', created.data.name);
+  console.log('    webViewLink:', created.data.webViewLink);
+  console.log('    driveId:', created.data.driveId ?? '(none)');
+
+  // Step 3: write content.
+  console.log('\n[3] write content...');
+  await drive.files.update({
+    fileId,
+    media: { mimeType: 'text/plain', body: 'Hello from the ACE service account!\n' },
+    fields: 'id',
+    supportsAllDrives: true,
+  });
+  console.log('    ok');
+
+  // Step 4: clean up — trash the file so we don't leave noise.
+  console.log('\n[4] cleanup (trash the test file)...');
+  await drive.files.update({
+    fileId,
+    requestBody: { trashed: true },
+    supportsAllDrives: true,
+  });
+  console.log('    ok');
+
+  console.log('\nSUCCESS: service account can create, update, and trash docs in the folder.');
+}
+
+main().catch((err) => {
+  console.error('\nFAILED:', err?.message ?? err);
+  if (err?.errors) console.error(JSON.stringify(err.errors, null, 2));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Shared Drive support** — every `drive.files.*` call in `mcp/google-drive-server.ts` now passes `supportsAllDrives: true` (and `includeItemsFromAllDrives: true` on list calls). Without this, Drive API silently treats writes as "My Drive" operations and rejects them with `Service Accounts do not have storage quota`, even when the target folder lives in a Shared Drive. ACE skills can now create/update docs inside the ACE folder under the Shared Drive.
- **Env-var-based key resolution** — the SA key path now comes from `GOOGLE_APPLICATION_CREDENTIALS` (Google's standard env var). `.mcp.json` sets it to `${CLAUDE_PLUGIN_DATA}/gws-sa-key.json`, which Claude Code expands at MCP server launch. That location is outside the versioned plugin cache dir, so it survives `/ace:update` and is shared across worktrees and installs — drop the key once per machine, not once per checkout. Falls back to the legacy `<plugin-root>/.gws-sa-key.json` for in-repo dev workflows.
- **Setup + doctor updated** — `/ace:setup` and `/ace:doctor` now probe the canonical `$CLAUDE_PLUGIN_DATA` path first, warn on legacy installs, and print the exact `mkdir -p … && mv … && chmod 600` command for first-time setup.
- **Doc cleanup** — README, design spec, and `commands/update.md` no longer reference the retired `gws-local-dev@dimagi-chrome-extension` service account or the legacy copy-forward logic. Adds a Shared Drive requirement note to the README.

## Test plan

- [x] `scripts/test-sa-create.ts` with `GOOGLE_APPLICATION_CREDENTIALS` unset → `Key source: legacy` → creates + writes + trashes a doc in the ACE Shared Drive folder → SUCCESS
- [x] Same script with `GOOGLE_APPLICATION_CREDENTIALS=/tmp/...` → `Key source: env` → SUCCESS
- [x] Folder metadata confirms `driveId` set (i.e. actually in a Shared Drive)
- [ ] After merge: `/ace:update` → `/reload-plugins` → `/ace:setup` → drops key at canonical `$CLAUDE_PLUGIN_DATA/gws-sa-key.json` path → `/ace:doctor` reports PASS → end-to-end skill run creates artifacts in the ACE folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)