### PR TITLE
feat(skills): add email-communicator skill + GOG CLI Gmail integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,5 +40,16 @@ OCS_SHARED_COLLECTION_ID=
 # OCS_BOOTSTRAP_FORCE=1     Archive the existing golden template before
 #                          recreating it.
 
+# ── Gmail (email-communicator skill, uses GOG CLI) ──
+#
+# GOG must be installed (brew install steipete/tap/gogcli) and authenticated:
+#   gog auth credentials set /path/to/client_secret.json --client <client_name>
+#   gog login <account> --client <client_name> --services gmail
+
+# Gmail account used by ACE for all email communication
+ACE_GMAIL_ACCOUNT=
+# GOG OAuth client name (set during `gog auth credentials set`)
+ACE_GMAIL_CLIENT=
+
 # Playwright session state (gitignored; established via /ocs:login)
 ACE_SESSION_STATE_DIR=~/.ace

--- a/skills/email-communicator/SKILL.md
+++ b/skills/email-communicator/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: email-communicator
+description: >
+  Send and receive email via the GOG CLI using the ACE Gmail account.
+  Handles composing, sending, searching, reading, and replying to email
+  for any skill that needs email communication (onboarding, LLO comms,
+  feedback collection, etc.).
+---
+
+# Email Communicator
+
+Send and receive email through the ACE Gmail account using the GOG CLI. This is a utility skill — other skills delegate to it whenever they need to send or read email rather than reimplementing Gmail access themselves.
+
+## Configuration
+
+This skill requires the following environment variables (defined in `.env`):
+
+| Variable | Description |
+|----------|-------------|
+| `ACE_GMAIL_ACCOUNT` | The Gmail account to send/receive from |
+| `ACE_GMAIL_CLIENT` | The GOG OAuth client name for this account |
+
+The GOG CLI must be installed (`brew install steipete/tap/gogcli`) and authenticated for the configured account before use. Run `gog login $ACE_GMAIL_ACCOUNT --client $ACE_GMAIL_CLIENT --services gmail` to authenticate.
+
+## Process
+
+1. **Resolve configuration.** Read `ACE_GMAIL_ACCOUNT` and `ACE_GMAIL_CLIENT` from environment. Abort with a clear error if either is unset.
+
+2. **Determine the operation.** The calling skill specifies one of: **send**, **reply**, **search**, or **read**.
+
+3. **For send operations:**
+   - Compose the email with recipient(s), subject, and body
+   - Use: `gog gmail send --account $ACE_GMAIL_ACCOUNT --client $ACE_GMAIL_CLIENT --to <recipient> --subject <subject> --body <body>`
+   - For CC: add `--cc <address>`
+   - For multiple recipients: repeat `--to` flags
+   - Capture the returned `message_id` and `thread_id` for logging
+
+4. **For reply operations:**
+   - Read the original message first (step 6) to get the thread context
+   - Use: `gog gmail reply --account $ACE_GMAIL_ACCOUNT --client $ACE_GMAIL_CLIENT <message_id> --body <body>`
+   - Replies maintain the thread automatically
+
+5. **For search operations:**
+   - Use: `gog gmail search "<query>" --account $ACE_GMAIL_ACCOUNT --client $ACE_GMAIL_CLIENT --json`
+   - Common queries:
+     - `from:<address>` — messages from a specific sender
+     - `to:<address>` — messages sent to a specific address
+     - `subject:<text>` — messages with subject containing text
+     - `in:inbox` — inbox messages
+     - `is:unread` — unread messages
+     - `newer_than:1d` — messages from the last day
+   - Combine with spaces: `from:user@example.com subject:onboarding is:unread`
+   - Returns thread list with IDs, dates, senders, subjects
+
+6. **For read operations:**
+   - Use: `gog gmail read --account $ACE_GMAIL_ACCOUNT --client $ACE_GMAIL_CLIENT <message_id> --json`
+   - Returns full message content including headers and body
+
+7. **Log the operation.** Return the operation result (message IDs, thread IDs, search results) to the calling skill for logging to the opportunity's comms log in GDrive.
+
+## MCP Tools Used
+
+None — this skill uses the GOG CLI via shell commands, not MCP tools.
+
+## Mode Behavior
+- **Auto:** Execute email operations directly, return results to calling skill
+- **Review:** For send/reply, present the composed email for human approval before sending. Search/read execute immediately.
+
+## Dry-Run Behavior
+
+When `--dry-run` is active:
+- **Send/reply:** Print the full email (to, cc, subject, body) to stdout but do not send. Return a synthetic message ID for logging.
+- **Search/read:** Execute normally (read-only operations are safe in dry-run).
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-04-10 | Initial version | ACE team |

--- a/skills/llo-onboarding/SKILL.md
+++ b/skills/llo-onboarding/SKILL.md
@@ -17,7 +17,7 @@ Send onboarding communications to LLOs who accepted the opportunity invitation.
    - Opportunity details: `ACE/<opp-name>/connect-setup/opportunity.md`
 
 2. **For each invited LLO, compose an onboarding email:**
-   - From: Ace-AI@Dimagi.com
+   - From: `$ACE_GMAIL_ACCOUNT` (via `email-communicator` skill)
    - CC: CRISPR Admin Dimagi Google Group
    - Subject: "[Opportunity Name] — Welcome and Next Steps"
    - Body:
@@ -25,10 +25,10 @@ Send onboarding communications to LLOs who accepted the opportunity invitation.
      - Links to training materials (GDrive links or attachments)
      - Step-by-step instructions for getting started
      - Timeline and expectations
-     - How to ask questions (email Ace-AI@Dimagi.com — handled by OCS)
+     - How to ask questions (email `$ACE_GMAIL_ACCOUNT` — handled by OCS)
      - Contact info for escalation
 
-3. **Send emails** (or draft for review).
+3. **Send emails** via the `email-communicator` skill (or draft for review).
 
 4. **Log communications** to `ACE/<opp-name>/comms-log/onboarding-emails.md`.
 


### PR DESCRIPTION
## Summary
- Add `email-communicator` skill for sending/receiving email via GOG CLI (send, reply, search, read)
- Account config is env-driven (`ACE_GMAIL_ACCOUNT`, `ACE_GMAIL_CLIENT`) — no hardcoded addresses in skills
- Update `llo-onboarding` to delegate to `email-communicator` instead of hardcoding `Ace-AI@Dimagi.com`
- Add Gmail env vars to `.env.example` with setup instructions

## Test plan
- [x] GOG CLI installed and authenticated for `ace@dimagi-ai.com`
- [x] Verified send and receive work (`gog gmail send`, `gog gmail search`)
- [x] Skill follows author contract (sequential steps, required sections, change log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)