### PR TITLE
fix: resolve Drive shortcuts in drive_read_file

### DIFF
--- a/mcp/google-drive-server.ts
+++ b/mcp/google-drive-server.ts
@@ -258,7 +258,7 @@ server.tool(
     try {
       const resp = await drive.files.list({
         q: `'${folderId}' in parents and trashed = false`,
-        fields: 'files(id, name, mimeType, modifiedTime, webViewLink)',
+        fields: 'files(id, name, mimeType, modifiedTime, webViewLink, shortcutDetails)',
         orderBy: 'name',
         supportsAllDrives: true,
         includeItemsFromAllDrives: true,
@@ -279,15 +279,29 @@ server.tool(
   },
   async ({ fileId }) => {
     try {
-      const meta = await drive.files.get({ fileId, fields: 'mimeType, name', supportsAllDrives: true });
-      const mimeType = meta.data.mimeType || '';
+      const meta = await drive.files.get({ fileId, fields: 'mimeType, name, shortcutDetails', supportsAllDrives: true });
+      let resolvedId = fileId;
+      let mimeType = meta.data.mimeType || '';
+
+      // If the file is a Drive shortcut, resolve to the target file.
+      // Shortcuts have their own mimeType (application/vnd.google-apps.shortcut)
+      // and store the target's ID and mimeType in shortcutDetails.
+      if (mimeType === 'application/vnd.google-apps.shortcut') {
+        const targetId = (meta.data as any).shortcutDetails?.targetId;
+        const targetMimeType = (meta.data as any).shortcutDetails?.targetMimeType;
+        if (!targetId) {
+          return error('Shortcut has no target file ID');
+        }
+        resolvedId = targetId;
+        mimeType = targetMimeType || '';
+      }
 
       let content: string;
       if (mimeType === 'application/vnd.google-apps.document') {
-        const resp = await drive.files.export({ fileId, mimeType: 'text/plain' }, { responseType: 'text' });
+        const resp = await drive.files.export({ fileId: resolvedId, mimeType: 'text/plain' }, { responseType: 'text' });
         content = resp.data as string;
       } else {
-        const resp = await drive.files.get({ fileId, alt: 'media', supportsAllDrives: true }, { responseType: 'text' });
+        const resp = await drive.files.get({ fileId: resolvedId, alt: 'media', supportsAllDrives: true }, { responseType: 'text' });
         content = resp.data as string;
       }
 


### PR DESCRIPTION
## Summary

- **`drive_read_file`**: When a file ID points to a Google Drive shortcut (`application/vnd.google-apps.shortcut`), the tool now resolves `shortcutDetails.targetId` and `shortcutDetails.targetMimeType` before deciding whether to export (Docs) or download (binary). Previously, shortcuts fell through to the binary download path and failed with *"Only files with binary content can be downloaded."*
- **`drive_list_folder`**: Now includes `shortcutDetails` in the returned fields so agents can see what each shortcut points to without a separate metadata call.

## Bug

When `drive_read_file` was called with a shortcut file ID, the metadata call returned `mimeType: "application/vnd.google-apps.shortcut"` instead of the target file's type. The tool didn't handle this case, so it fell into the binary download branch and errored because the Drive API refuses binary downloads on Docs Editor files.

## Fix

1. Request `shortcutDetails` in the metadata fields
2. If the mimeType is `application/vnd.google-apps.shortcut`, extract `targetId` and `targetMimeType` from `shortcutDetails`
3. Use the resolved target ID and mimeType for the subsequent export/download call
4. Gracefully error if `shortcutDetails.targetId` is missing

## Test plan

- [ ] Call `drive_read_file` with a shortcut pointing to a Google Doc -- should return plain text content
- [ ] Call `drive_read_file` with a shortcut pointing to a plain text file -- should download correctly
- [ ] Call `drive_read_file` with a regular (non-shortcut) Google Doc -- unchanged behavior
- [ ] Call `drive_list_folder` on a folder containing shortcuts -- verify `shortcutDetails` appears in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)