### PR TITLE
feat(upload-transcript): pass opp linkage fields to ace-web

### DIFF
--- a/commands/run.md
+++ b/commands/run.md
@@ -89,8 +89,13 @@ full resolution flow. Short version:
      `claude -p --output-format stream-json > <file>`). If the transcript
      path is not available in the run context, log a warning and skip
      the upload — do not fail the overall run.
-   - Dispatch the `upload-transcript` skill with `base_url=<URL>` and
-     `transcript_path=<resolved-path>`.
+   - Dispatch the `upload-transcript` skill with:
+     - `base_url=<URL>`
+     - `transcript_path=<resolved-path>`
+     - `opp_slug=<opp-name>` so the uploaded Session is linked under the
+       opp in the Workbench's linked-chats panel (strongly recommended
+       — without it the transcript is an orphan upload)
+     - `opp_run_id=r1` (current single-run convention)
    - Log the returned `session_slug` and the viewable URL
      (`<URL>/chat/<session_slug>`) to the operator's console.
 

--- a/skills/upload-transcript/SKILL.md
+++ b/skills/upload-transcript/SKILL.md
@@ -17,7 +17,16 @@ shared-secret flow — no per-user personal tokens.
 - `ACE_E2E_AUTH_TOKEN` — env var; shared secret from the target instance's
   `deploy/aws/task-definition.json` or AWS Secrets Manager.
 
-Optional: `email` (defaults to `ace@dimagi-ai.com`).
+Optional:
+- `email` (defaults to `ace@dimagi-ai.com`).
+- `opp_slug` — ACE opportunity slug to link the transcript to. When set,
+  the resulting Session is surfaced under the opp in the Workbench's
+  "linked chats" panel for that step. Strongly recommended when invoked
+  from `/ace:run --ace-web-url`.
+- `opp_run_id` — currently always `r1`; reserved for multi-run.
+- `opp_step_skill` — if the transcript is scoped to a single skill
+  invocation (e.g. just the `idea-to-pdd` run, not the full `/ace:run`
+  lifecycle), set this so the linkage points at the specific step.
 
 ## Steps
 
@@ -41,6 +50,9 @@ Optional: `email` (defaults to `ace@dimagi-ai.com`).
    - `-H "X-CSRFToken: <csrf-value-from-jar>"`
    - `-H "Referer: <base-url>/"`
    - `-F "file=@<transcript_path>;type=application/x-ndjson"`
+   - `-F "opp_slug=<slug>"` (if provided)
+   - `-F "opp_run_id=<run_id>"` (if provided; usually `r1`)
+   - `-F "opp_step_skill=<skill>"` (if provided)
    Expect 201. On non-201, print the response body and fail.
 
 5. **Return** the `data.session_slug` from the 201 response envelope as the
@@ -64,12 +76,20 @@ HTTP=$(curl -sS -c "$COOKIE_JAR" -o /tmp/login-resp.json -w '%{http_code}' \
 curl -sS -b "$COOKIE_JAR" -c "$COOKIE_JAR" -o /dev/null "$BASE_URL/"
 CSRF=$(awk '$6 == "csrftoken_ace" { print $7 }' "$COOKIE_JAR" | tail -n 1)
 
-# 3. upload
+# 3. upload — optional opp/run/step linkage surfaces under that opp in
+# the Workbench's linked-chats panel. Omit any field you don't have.
+UPLOAD_ARGS=(
+  -F "file=@$TRANSCRIPT_PATH;type=application/x-ndjson"
+)
+[ -n "${OPP_SLUG:-}" ]       && UPLOAD_ARGS+=(-F "opp_slug=$OPP_SLUG")
+[ -n "${OPP_RUN_ID:-}" ]     && UPLOAD_ARGS+=(-F "opp_run_id=$OPP_RUN_ID")
+[ -n "${OPP_STEP_SKILL:-}" ] && UPLOAD_ARGS+=(-F "opp_step_skill=$OPP_STEP_SKILL")
+
 HTTP=$(curl -sS -b "$COOKIE_JAR" -o /tmp/upload-resp.json -w '%{http_code}' \
   -X POST "$BASE_URL/api/ingest/upload" \
   -H "X-CSRFToken: $CSRF" \
   -H "Referer: $BASE_URL/" \
-  -F "file=@$TRANSCRIPT_PATH;type=application/x-ndjson")
+  "${UPLOAD_ARGS[@]}")
 [ "$HTTP" = "201" ] || { echo "upload $HTTP"; cat /tmp/upload-resp.json; exit 4; }
 
 # 4. extract session slug from envelope {data: {session_slug: "..."}}


### PR DESCRIPTION
## Summary
- `upload-transcript` SKILL.md: documents optional `opp_slug` / `opp_run_id` / `opp_step_skill` multipart fields, updates the curl reference to pass them
- `/ace:run --ace-web-url`: defaults `opp_slug=<opp-name>` and `opp_run_id=r1` so transcripts from a full run are auto-linked in the Workbench's linked-chats panel (no more orphan uploads)

## Context
Pairs with the ace-web PR that adds these fields to `/api/ingest/upload`. Fields are optional — existing callers without linkage still get a valid upload.

## Test plan
- [ ] `/ace:run --ace-web-url <url> <opp-name>` uploads a transcript and the resulting chat session shows `opp_slug=<opp-name>` in the ace-web Workbench
- [ ] `upload-transcript` invoked directly without opp fields still succeeds (orphan upload path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)