### PR TITLE
fix(package.json): strip leftover merge-conflict markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "ace",
-<<<<<<< HEAD
   "version": "0.10.61",
-=======
-  "version": "0.10.61",
->>>>>>> emdash/mobile-7aloq
   "description": "AI Connect Engine - orchestrator for building Connect Opps using AI",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Sister fix to 5fbd80d which missed package.json — leftover markers break npm install (reproduced in ace-web Docker build).