### PR TITLE
fix(env-tpl): drop literal {{ }} from training-deck comment so op inject parses

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -103,8 +103,15 @@ ACE_AVD_NAME=ACE_Pixel_API_34
 # ─── ACE Training Deck (Slides) ────────────────────────────────────
 # Populated by `npx tsx scripts/bootstrap-training-deck-template.ts`.
 # The template deck has stencil slides the `training-deck-build` skill
-# duplicates and fills via {{TITLE}} / {{SUBTITLE}} / {{BODY}}
-# placeholders. Iterate branding/layout in Slides directly; do NOT
-# change stencil objectIds or placeholder tokens (they're wired to
-# `lib/training-deck-spec.ts`).
+# duplicates and fills via Mustache-style TITLE / SUBTITLE / BODY
+# placeholder tokens (see `lib/training-deck-spec.ts` for the exact
+# token list). Iterate branding/layout in Slides directly; do NOT
+# change stencil objectIds or placeholder tokens.
+#
+# NOTE: literal Mustache-brace examples are deliberately omitted
+# from this comment because `op inject` parses the entire file
+# (comments included) and rejects any unescaped double-curly-brace
+# block that isn't a valid 1Password secret reference or quoted
+# string. See commit b07a0a5 for the prior secret-reference-in-comment
+# incident (same root cause, different syntax).
 ACE_TRAINING_DECK_TEMPLATE_ID=


### PR DESCRIPTION
## Summary
- `.env.tpl` line 106 contained literal `{{TITLE}} / {{SUBTITLE}} / {{BODY}}` (Slides Mustache placeholder docs) that `op inject` parses as malformed secret refs
- The whole `op inject -i .env.tpl -o ...` step aborts with `parsing error at 106:30`, so deployed containers (ace-web on AWS Fargate) end up with no rendered `.env` and any ACE MCP needing OCS/HQ/Gmail/Connect creds 401s silently
- Same root cause as commit b07a0a5 (op:// in a comment) — rephrase the comment to drop the literal `{{ }}` so the parser ignores it

## Why this matters
This is the v7 Tier C regression: ace-web's chat fell back to REST/no-tools across all of Phase 2/3/4 because `op inject` silently failed at container start. With this fix, the entrypoint's three-mirror `.env` write actually has content to mirror, so the ACE plugin's MCPs come up authenticated.

## Test plan
- [x] `op inject -i .env.tpl -o /tmp/test.env` against AI-Agents vault — resolves 117 lines cleanly
- [ ] After merge: rebuild ace-web image, deploy, hit `/api/system/cli-diag`, confirm ace-ocs / ace-connect / ace-gdrive MCPs surface tools (vs. v7 where they didn't)

🤖 Generated with [Claude Code](https://claude.com/claude-code)