### PR TITLE
fix(connect-program-setup): write Program URL to program.md

### DIFF
--- a/skills/connect-program-setup/SKILL.md
+++ b/skills/connect-program-setup/SKILL.md
@@ -50,6 +50,13 @@ Create or select a Connect program for this opportunity.
 5. **Write program details** to `ACE/<opp-name>/connect-setup/program.md`:
    - Program ID (UUID)
    - Program name
+   - **URL** — the program detail page on Connect (mirrors the URL line
+     `connect-opp-setup` writes for the opportunity). Pattern:
+     `https://connect.dimagi.com/a/<organization_slug>/program/<program-uuid>/view`
+     (note: `program/` singular, matching upstream
+     `commcare-connect/program/urls.py`'s `<slug:pk>/view` pattern). Format
+     as `**URL:** <url>` so downstream readers (ace-web's public
+     summary page) can extract it the same way they do the opportunity URL.
    - Archetype declared at program creation (if new)
    - Whether reused or newly created; note any archetype mismatch if reused
    - Configuration details (delivery_type name + id, budget, currency,


### PR DESCRIPTION
## Summary

Step 5 of ``connect-program-setup`` lists Program ID, name, archetype, and config details to persist to ``connect-setup/program.md`` — but not the program's Connect URL. Sibling ``connect-opp-setup`` writes ``**URL:**`` for the opportunity; ace-web's public summary page extracts both the same way and ends up with a text-only program row when this is missing.

This adds the Program URL line to the skill's step 5 output requirement, with the upstream commcare-connect URL pattern (``program/`` singular, ``/view`` suffix).

ace-web has a fallback that constructs the URL from the program UUID + the org slug pulled from the opportunity URL (jjackson/ace-web#222), so the public page works today regardless. This PR makes the URL durable in the artifact for any other consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)