### PR TITLE
refactor(decisions): v2 schema — ai-default + overridden

### DIFF
--- a/lib/decisions-parser.ts
+++ b/lib/decisions-parser.ts
@@ -4,7 +4,7 @@
  * Walks the document body in paragraph order. HEADING_3 paragraphs are
  * decision-row boundaries (the row id). Within a decision section,
  * subsequent paragraphs are scanned for:
- *   - "Default: <value>"  → row.default
+ *   - "AI default: <value>"  → row.default (the parsed override value)
  *   - "Considered:"       → enters bullet-collection mode
  *   - bullet paragraphs   → appended to row.options_considered
  *   - "Source:" / "Status:" → exits bullet-collection mode; not extracted
@@ -121,6 +121,17 @@ export function parseDocumentStructure(
     }
 
     // Field-prefix detection (case-insensitive, strip leading indent).
+    if (/^AI default:/i.test(trimmed)) {
+      current.default = trimmed.replace(/^AI default:\s*/i, "").trim();
+      continue;
+    }
+
+    if (/^Override:/i.test(trimmed)) {
+      current.default = trimmed.replace(/^Override:\s*/i, "").trim();
+      continue;
+    }
+
+    // Legacy v1 docs used "Default:" — parse it too for old docs.
     if (/^Default:/i.test(trimmed)) {
       current.default = trimmed.replace(/^Default:\s*/i, "").trim();
       continue;

--- a/lib/decisions-renderer.ts
+++ b/lib/decisions-renderer.ts
@@ -256,9 +256,6 @@ const INTRO =
 // ── Status rendering ──────────────────────────────────────────────────────────
 
 function statusValue(status: DecisionRow["status"]): string {
-  if (status === "open") {
-    return "OPEN — load-bearing; human edit recommended";
-  }
   return status;
 }
 
@@ -271,8 +268,11 @@ function renderDecision(builder: RequestBuilder, row: DecisionRow): void {
   // Bold question
   builder.appendBold(row.question);
 
-  // Default: <value>
-  builder.appendBoldPrefix("Default:", row.default);
+  // AI default: <value>
+  builder.appendBoldPrefix("AI default:", row["ai-default"]);
+  if (row.override) {
+    builder.appendBoldPrefix("Override:", row.override);
+  }
 
   // Considered: (bold label) then bullet list
   builder.appendBoldLabel("Considered:");

--- a/lib/decisions-schema.ts
+++ b/lib/decisions-schema.ts
@@ -4,41 +4,60 @@ import yaml from "yaml";
 /**
  * Canonical schema version for the decisions log. Bump when introducing
  * a breaking change; pair with a migration in `migrations/`.
+ *
+ * v2 (2026-05-23): rename `default:` → `ai-default:`, add optional
+ * `override:`, status enum is now `ai-default | overridden`.
  */
-export const DECISIONS_SCHEMA_VERSION = 1 as const;
+export const DECISIONS_SCHEMA_VERSION = 2 as const;
 
 /**
  * One row in a per-run decisions log. Represents a load-bearing default
- * an ACE phase applied (or a load-bearing decision the AI flagged for
- * human attention while still proceeding with a default).
+ * an ACE phase applied. When a human overrides via the workbench or
+ * Slack, the override value is stored in `override:` and `ai-default:`
+ * is preserved as the AI's original proposal.
  *
- * See docs/superpowers/specs/2026-05-08-decisions-log-design.md § Schema
- * for field semantics and the bar criterion that gates row creation.
+ * Effective value = `override` if present, else `ai-default`.
  */
-export const DecisionRowSchema = z.object({
-  id: z.string().regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
-    message: "id must be canonical kebab-case (lowercase alphanumeric segments separated by single hyphens)",
-  }),
-  phase: z.string().regex(/^[1-9][0-9]*-[a-z]+(-[a-z]+)*$/, {
-    message: "phase must match <N>-<kebab-name> (e.g. 1-design, 3-commcare)",
-  }),
-  skill: z.string().min(1),
-  question: z.string().min(1),
-  default: z.string().min(1),
-  options_considered: z.array(z.string().min(1)),
-  source: z.string().min(1),
-  status: z.enum(["applied", "overridden", "open"]),
-  notes: z.string().optional(),
-});
+export const DecisionRowSchema = z
+  .object({
+    id: z.string().regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
+      message:
+        "id must be canonical kebab-case (lowercase alphanumeric segments separated by single hyphens)",
+    }),
+    phase: z.string().regex(/^[1-9][0-9]*-[a-z]+(-[a-z]+)*$/, {
+      message: "phase must match <N>-<kebab-name> (e.g. 1-design, 3-commcare)",
+    }),
+    skill: z.string().min(1),
+    question: z.string().min(1),
+    "ai-default": z.string().min(1),
+    override: z.string().min(1).optional(),
+    options_considered: z.array(z.string().min(1)),
+    source: z.string().min(1),
+    status: z.enum(["ai-default", "overridden"]),
+    notes: z.string().optional(),
+  })
+  .superRefine((row, ctx) => {
+    if (row.status === "overridden" && row.override === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "status=overridden requires `override` field",
+        path: ["override"],
+      });
+    }
+    if (row.status === "ai-default" && row.override !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "status=ai-default must not have `override` field",
+        path: ["override"],
+      });
+    }
+  });
 
 export type DecisionRow = z.infer<typeof DecisionRowSchema>;
 
 /**
  * The full per-run log file shape. Stored at
  * ACE/<opp>/runs/<run-id>/decisions.yaml.
- *
- * See docs/superpowers/specs/2026-05-08-decisions-log-design.md § Schema
- * for field semantics.
  */
 export const DecisionsLogSchema = z
   .object({
@@ -69,10 +88,14 @@ export type DecisionsLog = z.infer<typeof DecisionsLogSchema>;
  * Throws an Error whose message lists the dot-paths of each offending
  * field (e.g. "decisions.0.id") if validation fails.
  * Throws YAMLParseError if the YAML itself is unparseable.
+ *
+ * Transparently upgrades v1-shape input to v2 in memory so live runs
+ * survive the schema bump without an explicit migration pass.
  */
 export function parseDecisionsYaml(input: string): DecisionsLog {
   const raw = yaml.parse(input);
-  const result = DecisionsLogSchema.safeParse(raw);
+  const upgraded = maybeUpgradeFromV1(raw);
+  const result = DecisionsLogSchema.safeParse(upgraded);
   if (!result.success) {
     const paths = result.error.issues
       .map((issue) => issue.path.join("."))
@@ -83,21 +106,65 @@ export function parseDecisionsYaml(input: string): DecisionsLog {
 }
 
 /**
+ * In-memory upgrade of a v1 decisions log to v2.
+ *
+ * v1 row:                   v2 row:
+ *   default: X        →        ai-default: X
+ *   status: applied   →        status: ai-default
+ *   status: open      →        status: ai-default
+ *   status: overridden →       status: overridden + override: X
+ */
+function maybeUpgradeFromV1(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const log = raw as { schema_version?: unknown; decisions?: unknown };
+  if (log.schema_version !== 1) return raw;
+  if (!Array.isArray(log.decisions)) return raw;
+
+  const upgradedRows = log.decisions.map((r) => {
+    if (typeof r !== "object" || r === null) return r;
+    const row = r as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...row };
+
+    if ("default" in out && !("ai-default" in out)) {
+      out["ai-default"] = out["default"];
+      delete out["default"];
+    }
+
+    if (out["status"] !== "overridden") {
+      out["status"] = "ai-default";
+    }
+
+    if (out["status"] === "overridden" && !("override" in out)) {
+      const aiDefault = out["ai-default"];
+      if (typeof aiDefault === "string") {
+        out["override"] = aiDefault;
+      }
+    }
+
+    return out;
+  });
+
+  return { ...log, schema_version: 2, decisions: upgradedRows };
+}
+
+/**
  * Serialize a DecisionsLog into a YAML string suitable for writing to
  * ACE/<opp>/runs/<run-id>/decisions.yaml.
  *
- * - lineWidth: 0 — the `yaml` package disables block-scalar folding when
- *   lineWidth is 0 or negative; long `notes` paragraphs stay one-line so
- *   diffs are readable.
- * - aliasDuplicateObjects: false — suppresses `&ref_0`/`*ref_0` YAML
- *   anchors when two decisions share an identical `notes` or option
- *   string. Anchors are valid YAML but unreadable for human reviewers.
+ * - lineWidth: 0 — disables block-scalar folding so diffs are readable.
+ * - aliasDuplicateObjects: false — suppresses YAML anchors.
  */
 export function serializeDecisionsLog(log: DecisionsLog): string {
-  // Validate before emitting — catches caller errors before we write.
   DecisionsLogSchema.parse(log);
   return yaml.stringify(log, null, {
     lineWidth: 0,
     aliasDuplicateObjects: false,
   });
+}
+
+/**
+ * Effective value for a row: the override if present, else the AI default.
+ */
+export function effectiveValue(row: DecisionRow): string {
+  return row.override ?? row["ai-default"];
 }

--- a/lib/decisions-sync.ts
+++ b/lib/decisions-sync.ts
@@ -46,20 +46,21 @@ function mergeRow(
   if (!parsedRow) return yamlRow;
 
   let updated: DecisionRow = yamlRow;
+  const currentValue = yamlRow.override ?? yamlRow["ai-default"];
 
-  if (parsedRow.default !== undefined && parsedRow.default !== yamlRow.default) {
+  if (parsedRow.default !== undefined && parsedRow.default !== currentValue) {
     const newOptions = [...yamlRow.options_considered];
-    if (!newOptions.includes(yamlRow.default)) newOptions.push(yamlRow.default);
+    if (!newOptions.includes(currentValue)) newOptions.push(currentValue);
     if (!newOptions.includes(parsedRow.default)) newOptions.push(parsedRow.default);
     updated = {
       ...updated,
-      default: parsedRow.default,
+      override: parsedRow.default,
       status: "overridden",
       options_considered: newOptions,
     };
     report.defaultsOverridden.push({
       id: yamlRow.id,
-      from: yamlRow.default,
+      from: currentValue,
       to: parsedRow.default,
     });
   }

--- a/skills/idea-to-pdd/SKILL.md
+++ b/skills/idea-to-pdd/SKILL.md
@@ -126,8 +126,8 @@ orchestrator from the per-skill QA + eval verdicts on the fly. -->
     bar criterion in `## Decisions Log Convention` below. Each row
     records a load-bearing default the skill is about to apply when
     drafting the PDD. Use the AI's best inference from the source
-    material for each `default` value; mark `status: open` for any
-    default the AI flags for human attention while still proceeding.
+    material for each `ai-default` value; use `status: ai-default`
+    for all rows (the human can override later via the workbench).
 
     See `## Decisions Log Convention § Common load-bearing decisions for
     Phase 1` for a working template of decisions that often qualify under
@@ -364,18 +364,11 @@ Write via `drive_create_file` (find-or-update semantics) at
 `ACE/<opp-name>/runs/<run-id>/decisions.yaml`. The Drive MCP's parent
 folder is the run-folder file ID resolved at run start.
 
-### Status: `open` policy
+### Status values
 
-A row is marked `status: open` when a load-bearing default exists but the
-AI judges it likely-wrong without human confirmation. Examples:
-
-- `named-downstream-consumer` is `none-named-proceed-with-caveat` AND
-  the opp will publish a public solicitation in Phase 8.
-- `ai-fallback-design` is `parallel-sampling-N-percent` AND the program
-  needs ground-truth per-decision accuracy.
-
-The AI proceeds with the default in either mode; review-mode pauses for
-edit, default-mode ships the gate brief with `[WARN]` entries.
+All decisions written by the skill use `status: ai-default`. Human
+overrides (via the workbench or Slack) change the status to `overridden`
+and populate the `override:` field.
 
 ## Archetypes
 


### PR DESCRIPTION
## Summary
- Bump `DECISIONS_SCHEMA_VERSION` to 2
- Field rename: `default` → `ai-default`, add optional `override`
- Status enum: `ai-default | overridden` (drop `applied` / `open`)
- v1 input auto-upgraded via `maybeUpgradeFromV1` in the parser
- Renderer writes "AI default:" / "Override:" labels; parser reads both new and legacy formats
- Sync module merges parsed doc edits into `override` field

Paired with ace-web [PR #548](https://github.com/jjackson/ace-web/pull/548).

## Test plan
- [x] Schema validates v2 rows with ai-default/overridden statuses
- [x] v1 upgrade path maps applied/open → ai-default
- [ ] End-to-end: run an opp, verify decisions.yaml writes v2 shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)