### PR TITLE
skills(phase-3): flip disable-model-invocation false on the 7 commcare-setup skills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ace",
-  "version": "0.13.403",
+  "version": "0.13.420",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ace",
-      "version": "0.13.403",
+      "version": "0.13.420",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.94.0",

--- a/skills/app-connect-coverage/SKILL.md
+++ b/skills/app-connect-coverage/SKILL.md
@@ -3,7 +3,7 @@ name: app-connect-coverage
 description: >
   Verify every form in a Nova-built Learn or Deliver app has the right
   CommCare Connect markers, auto-fix via Nova edits, loop until clean.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # App Connect Coverage

--- a/skills/app-deploy/SKILL.md
+++ b/skills/app-deploy/SKILL.md
@@ -3,7 +3,7 @@ name: app-deploy
 description: >
   Upload Nova-built Learn + Deliver apps to CommCare HQ as draft
   builds via /nova:upload_to_hq. Captures HQ app IDs and writes a deploy summary.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # App Deploy

--- a/skills/app-release-smoke/SKILL.md
+++ b/skills/app-release-smoke/SKILL.md
@@ -7,7 +7,7 @@ description: >
   Connect-marker presence match the Nova blueprint. AVD-free, Connect-
   free — purely CCHQ-side structural verification. Halts loud on
   mismatch.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # App Release Smoke

--- a/skills/app-release/SKILL.md
+++ b/skills/app-release/SKILL.md
@@ -3,7 +3,7 @@ name: app-release
 description: >
   Build and release the Learn + Deliver CommCare apps on CCHQ so Connect
   can read their form schema and surface deliver units.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # App Release

--- a/skills/app-test-cases/SKILL.md
+++ b/skills/app-test-cases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Bind each PDD user journey to the Nova-built app structure and emit a
   Maestro recipe per journey with real selectors. Use after Nova
   finishes building, before app-release.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # App Test Cases

--- a/skills/pdd-to-deliver-app/SKILL.md
+++ b/skills/pdd-to-deliver-app/SKILL.md
@@ -3,7 +3,7 @@ name: pdd-to-deliver-app
 description: >
   Build the CommCare Deliver (service-delivery) app from the PDD via
   Nova's /nova:autobuild. Captures nova_app_id and writes a structure summary.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # PDD to Deliver App

--- a/skills/pdd-to-learn-app/SKILL.md
+++ b/skills/pdd-to-learn-app/SKILL.md
@@ -3,7 +3,7 @@ name: pdd-to-learn-app
 description: >
   Build the CommCare Learn (training) app from the PDD via Nova's
   /nova:autobuild. Captures nova_app_id and writes a structure summary.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # PDD to Learn App


### PR DESCRIPTION
## Summary

- Flip `disable-model-invocation: true` → `false` on the 7 Phase 3 skills (`pdd-to-learn-app`, `pdd-to-deliver-app`, `app-connect-coverage`, `app-deploy`, `app-test-cases`, `app-release`, `app-release-smoke`).
- Surgical unblock for `/ace:run` Phase 3, which is executed inline at L0 by `agents/commcare-setup.md` (procedure-doc, not a subagent).

## Why this is needed

The 2026-05-06 audit (`d62b26d`, `0.13.34`) blanket-applied `disable-model-invocation: true` to all ACE skills with the rationale "orchestrator-dispatched, never free-text invoked." That assumption held for subagent-dispatched phases (1, 2, 4–10): the parent `Agent(<phase>)` dispatch satisfies the platform's invocation chain, so the subagent can call `Skill(<name>)` internally without tripping the flag.

It does NOT hold for procedure-doc phases. `agents/commcare-setup.md` is executed inline by the L0 model because Phase 3 dispatches Nova-architect via `Agent`, and `Agent` is only available at L0 — running Phase 3 itself as a subagent would put Nova's dispatch at level 2 and break. So the orchestrator IS the model for Phase 3, and `Skill(pdd-to-learn-app)` from L0 looks like model invocation. Platform refuses. Phase 3 of `/ace:run` is structurally bricked.

Empirically confirmed today on the `bednet-spot-check` smoke run (`bednet-spot-check/20260525-2022`):

> `Skill pdd-to-deliver-app cannot be used with Skill tool due to disable-model-invocation`

The run halted with `[BLOCKER]` `phases.commcare-setup.verdict: blocked-on-platform`. Phases 1 + 2 completed cleanly; Phase 3 never dispatched a Nova build.

## Scope

Surgical: only the 7 skills `agents/commcare-setup.md` invokes by name. The remaining ~98 flagged skills retain the flag for now — most are subagent-dispatched and unaffected. A follow-up PR can audit the rest (the small subset with generic-verb descriptions that could match casual user sentences keeps the flag; the niche ones drop it).

## Test plan

- [x] `scripts/version-bump.sh` bumped atomically (0.13.420 → 0.13.423; origin/main was at 0.13.422).
- [x] `git status` clean after staged commit.
- [ ] Auto-merge after `clean-install` CI passes.
- [ ] In existing session that hit the wall: run `/ace:update` + `/reload-plugins`, then `/ace:run bednet-spot-check/20260525-2022` to resume from Phase 3 with the flag flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)