### PR TITLE
docs: close State Schema gaps in orchestrator-reference (closes #518)

### DIFF
--- a/agents/orchestrator-reference.md
+++ b/agents/orchestrator-reference.md
@@ -44,14 +44,18 @@ last_actor_at: <ISO timestamp>  # updated on every skill invocation
 phases:
   idea-to-design:       # Phase 1
     idea-to-pdd: done|pending|error|dry-run-success|...
+    pdd-to-work-order: pending
   scenarios-and-acceptance:  # Phase 2
     pdd-to-test-prompts: done|pending|...
     pdd-to-app-journeys: done|pending|...
   commcare-setup:       # Phase 3
     pdd-to-learn-app: pending
     pdd-to-deliver-app: pending
+    app-connect-coverage: pending
     app-deploy: pending
     app-test-cases: pending
+    app-release: pending
+    app-release-smoke: pending
   connect-setup:        # Phase 4
     connect-program-setup: pending
     connect-opp-setup: pending
@@ -68,6 +72,14 @@ phases:
     training-deck-generate: pending
     training-deck-render: pending         # skipped if ACE_TRAINING_DECK_TEMPLATE_ID unset
     training-onboarding-email: pending    # last — links to other docs by URL
+  synthetic-data-and-workflows:  # Phase 7
+    synthetic-narrative-plan: pending
+    synthetic-data-generate: pending
+    synthetic-workflow-seed: pending
+    synthetic-workflow-polish: pending
+    synthetic-walkthrough-spec: pending
+    synthetic-walkthrough-run: pending    # canopy:walkthrough scores per scene
+    synthetic-summary: pending            # pure aggregator
   solicitation-management:  # Phase 8 — added 0.12.0
     solicitation-create: pending
     llo-invite: pending               # repurposed 0.12.0: emails solicitation URL to PDD-named candidates


### PR DESCRIPTION
## Summary

Closes #518. Fixes the five drift findings surfaced by the first `/ace:detect-structure-drift` Check E run.

- Add `pdd-to-work-order` under `idea-to-design`
- Add `app-connect-coverage`, `app-release`, `app-release-smoke` under `commcare-setup` (in workflow order)
- Add the full Phase 7 `synthetic-data-and-workflows` stanza between Phase 6 and Phase 8

Source-of-truth: agent frontmatter `skills:` arrays in `agents/idea-to-design.md`, `agents/commcare-setup.md`, `agents/synthetic-data-and-workflows.md`. Ordering follows each agent's Workflow section.

Markdown-only; no version bump, bundles with the next plugin release per the issue.

## Test plan

- [ ] Re-run `/ace:detect-structure-drift` — Check E should drop all five findings; other checks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)