### PR TITLE
docs: video narrative + workbench substrate spec + 3 staged plans

### DIFF
--- a/docs/superpowers/plans/2026-06-07-ace-adopt-narrative-contract.md
+++ b/docs/superpowers/plans/2026-06-07-ace-adopt-narrative-contract.md
@@ -1,0 +1,88 @@
+# ACE Adopts the Narrative Contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Make ACE (the plugin + ace-web) consume the canonical narrative/eval contract instead of hand-maintained copies — generate TS types from canopy's published JSON Schema, and have the ACE video skills *invoke* canopy's validators + `visual-judge` rather than reimplementing the methodology.
+
+**Architecture:** Vendor canopy's canonical narrative JSON Schema into each ACE repo and generate TS types from it (so `lib/verdict-schema.ts` and the new `narrative`/`evidence`/`gap` types are generated, not written). Wire the video authoring skills to call the canopy Python validators via CLI and `canopy:visual-judge` per beat — the "orchestrate canopy capabilities on top" model.
+
+**Tech Stack:** TypeScript (ACE plugin `lib/`, ace-web `frontend/`), Python (ace-web Django `apps/videos`), Markdown skills. `json-schema-to-typescript` for codegen.
+
+**DEPENDS ON:** `2026-06-07-canopy-narrative-substrate.md` landed in `jjackson/canopy` — i.e. the canonical schema exists at `scripts/narrative/schema/json/` on canopy `main`. Do not start before that merges.
+
+**Repos:** `jjackson/ace-web` (codegen + Django + frontend) and the ACE plugin (`lib/verdict-schema.ts`, video skills). Separate branches/PRs.
+
+---
+
+## Task 1: Generate `Verdict` + narrative TS types from the canopy schema (ACE plugin)
+
+**Files:**
+- Create: `scripts/sync-narrative-schema.sh` (vendor + codegen)
+- Create: `lib/generated/narrative-contract.ts` (generated — gitignored-from-edits, committed)
+- Modify: `lib/verdict-schema.ts` (re-export the generated `Verdict`; keep ACE-only helpers)
+- Modify: `package.json` (devDep `json-schema-to-typescript`; `gen:narrative` script)
+
+- [ ] **Step 1:** Add a sync script that copies the canopy JSON Schema into the ACE plugin and codegens TS. It resolves the canopy checkout the same way DDD skills do (`$HOME/emdash-projects/canopy` or the marketplace mirror):
+
+```bash
+#!/usr/bin/env bash
+# scripts/sync-narrative-schema.sh — vendor canopy's canonical narrative
+# JSON Schema and regenerate lib/generated/narrative-contract.ts.
+set -euo pipefail
+CANOPY="${CANOPY_REPO:-$HOME/emdash-projects/canopy}"
+[ -d "$CANOPY/scripts/narrative/schema/json" ] || CANOPY="$HOME/.claude/plugins/marketplaces/canopy"
+SRC="$CANOPY/scripts/narrative/schema/json"
+[ -d "$SRC" ] || { echo "canopy narrative schema not found at $SRC — is the canopy substrate PR merged?"; exit 1; }
+mkdir -p lib/generated/schema
+cp "$SRC"/*.json lib/generated/schema/
+# Codegen one barrel from the vendored schemas.
+npx json-schema-to-typescript -i 'lib/generated/schema/*.json' -o lib/generated/narrative-contract.ts --bannerComment '// GENERATED from canopy scripts/narrative/schema/json — do not edit. Run npm run gen:narrative.'
+echo "regenerated lib/generated/narrative-contract.ts"
+```
+
+Add to `package.json` scripts: `"gen:narrative": "bash scripts/sync-narrative-schema.sh"` and devDependency `json-schema-to-typescript`.
+
+- [ ] **Step 2:** Run `npm run gen:narrative`; commit `lib/generated/`.
+
+- [ ] **Step 3:** Replace the hand-written `Verdict` shape in `lib/verdict-schema.ts` with a re-export of the generated type, keeping any ACE-only helper functions:
+
+```ts
+// lib/verdict-schema.ts
+export type { Verdict, Dimension } from "./generated/narrative-contract";
+// ... keep ACE-specific helpers (e.g. verdict aggregation) below, now typed
+// against the generated Verdict so they can't drift from the canonical shape.
+```
+
+- [ ] **Step 4:** `npm test` + `npx tsc --noEmit`. Fix any call sites where the generated `Verdict` field names differ from the old hand-written ones (this surfaces the drift the contract is meant to kill). **Commit.**
+
+---
+
+## Task 2: ace-web consumes the contract (frontend types + backend validation)
+
+**Files:**
+- Modify: `frontend/package.json` (extend the existing `gen:api` pattern with a `gen:narrative` step), `frontend/src/api/` (generated narrative types)
+- Modify (optional): `apps/videos/` — validate stored narrative/verdict data against the JSON Schema (Python can `jsonschema`-validate or import canopy's pydantic if canopy is added as a dep)
+
+- [ ] **Step 1:** Mirror Task 1's codegen in `frontend/` so the React side imports generated narrative/verdict/scene types (the review UI in Stage 5 consumes these). Commit the generated file.
+- [ ] **Step 2 (optional):** In `apps/videos`, when storing a narrative/verdict run-package payload, validate it against the vendored JSON Schema (`jsonschema.validate`) so malformed AI output is rejected at the boundary — the same discipline canopy-web's `request_json` envelope relies on. **Commit.**
+
+---
+
+## Task 3: Wire the video skills to invoke canopy capabilities (ACE plugin)
+
+**Files:**
+- Modify: `skills/partnership-angles/SKILL.md`, `skills/video-spec-eval/SKILL.md` (and the per-beat eval path), and/or a new `skills/video-narrative/SKILL.md`
+
+- [ ] **Step 1:** Where the video authoring flow today flags grounding via `[TBD]` + rubric prose, add a call to canopy's validators on the structured narrative — e.g. `(cd "$CANOPY" && uv run python -m scripts.ddd.narrative_coherence "$NARRATIVE_YAML")` and `... scripts.ddd.spec_qa ...` — and gate on the returned `Verdict` (resolve `$CANOPY` with the DDD-skill pattern). This gives the video pipeline the falsifiability + outcome-leakage + provenance checks for free.
+- [ ] **Step 2:** Add a per-beat visual judge: after a render produces per-beat frames, dispatch `canopy:visual-judge` per beat with a video rubric (ACE Phase 6 already calls `visual-judge` — reuse that invocation shape). This closes the "eval judges narration text, never the frames" gap.
+- [ ] **Step 3:** Update `test/skill-atom-references.test.ts` / skill docs as needed; run `npm test`. **Commit.**
+
+---
+
+## Done criteria
+- `lib/verdict-schema.ts` (+ ace-web frontend) types are **generated** from canopy's JSON Schema; no hand-maintained duplicate `Verdict`.
+- `npm run gen:narrative` reproducibly regenerates from the vendored schema; drift is impossible (regen + diff in CI).
+- The video skills invoke canopy's `narrative_coherence` / `spec_qa` validators and `visual-judge` per beat, instead of duplicating the methodology in TS.
+
+## Note
+Keep a TS implementation ONLY for any validator that must run in-process in the Remotion render pipeline (per spec §4b); test it against fixtures generated from canopy's Python side so the two can't diverge.

--- a/docs/superpowers/plans/2026-06-07-canopy-narrative-substrate.md
+++ b/docs/superpowers/plans/2026-06-07-canopy-narrative-substrate.md
@@ -1,0 +1,105 @@
+# Canopy Narrative Substrate Extraction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Lift the generic narrative / evidence-gap / eval / review-package schemas out of the DDD-specific `scripts.ddd` namespace into a neutral `scripts/narrative/` package, so the contract is reusable by non-DDD consumers (ACE video, ace-web) and publishable as a canonical JSON Schema — with zero behavior change to DDD (its tests are the regression guard).
+
+**Architecture:** Move the generic pydantic models from `scripts/ddd/schemas/models.py` → `scripts/narrative/models.py`; leave `RunState` (the DDD converge-lifecycle) in DDD. A re-export shim in the old module keeps every existing importer (DDD modules, the walkthrough recorder, tests, and `python -m scripts.ddd.*` skill entry points) working unchanged. Repoint the walkthrough recorder to the neutral module (it should not depend on `ddd`). Emit the narrative JSON Schema to a canonical path that downstream repos consume.
+
+**Tech Stack:** Python 3.11, pydantic v2, uv, pytest. **Repo:** `jjackson/canopy`, branch off `main`. Tests run from repo root: `uv run pytest`.
+
+**Why:** `scripts.ddd.schemas.models` packs the generic substrate (`WhyBrief`, `Evidence`, `SpineItem`, `Gap`, `Persona`, `Feature`, `Scene`, `UnifiedSpec`, `Dimension`, `Verdict`, `Decision`, `NarrationItem`, `ReviewRequest`, the `Action` union + `ACTION_KINDS`) together with the DDD-only `RunState`. `scripts/walkthrough/_lib/recorder.py` already imports the `Action` vocabulary *from ddd* (a renderer depending on a methodology — backwards). Extraction fixes that coupling and makes the contract canonical.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0: Branch + baseline.** `git checkout main && git pull && git checkout -b feat/narrative-substrate`. Run `uv run pytest` from repo root; **record the pass count** — this is the regression gate for every task below. Run `python scripts/ddd/regen_json_schemas.py` and confirm it's a no-op (schemas already committed).
+
+---
+
+## Task 1: Create `scripts/narrative/` and move the generic models
+
+**Files:**
+- Create: `scripts/narrative/__init__.py`, `scripts/narrative/models.py`
+- Modify: `scripts/ddd/schemas/models.py` (becomes a re-export shim + keeps `RunState`)
+
+- [ ] **Step 1:** Create `scripts/narrative/__init__.py` (empty) and `scripts/narrative/models.py`. Into `models.py`, **move verbatim** from `scripts/ddd/schemas/models.py` everything EXCEPT the `RunState` class: the module header imports (`from __future__ import annotations`, `from typing import Annotated, Literal, Union`, `from pydantic import BaseModel, ConfigDict, Field`), and the classes/symbols `Evidence, SpineItem, Gap, WhyBrief, Persona, Feature, ACTION_KINDS, _ActionBase, GotoAction, ClickAction, ClickMenuAction, FillAction, SelectAction, TypeAction, PressAction, HoverAction, ScrollToAction, ScrollAction, WaitForAction, HoldAction, DrawAction, Action, Scene, UnifiedSpec, Dimension, Verdict, Decision, NarrationItem, ReviewRequest`. (Verify the exact symbol list against the file — move every top-level definition except `RunState`.)
+
+- [ ] **Step 2:** Rewrite `scripts/ddd/schemas/models.py` as a shim that re-exports the moved symbols and keeps `RunState` (which references `Verdict`):
+
+```python
+"""DDD schema module — re-exports the neutral narrative substrate and
+keeps the DDD-only RunState. The generic narrative / eval / review models
+now live in scripts/narrative/models.py (the canonical contract). This
+shim preserves every existing `from scripts.ddd.schemas.models import X`
+importer and the `python -m scripts.ddd.*` skill entry points."""
+from __future__ import annotations
+
+from scripts.narrative.models import (  # noqa: F401  (re-export)
+    Evidence, SpineItem, Gap, WhyBrief, Persona, Feature,
+    ACTION_KINDS, Action,
+    GotoAction, ClickAction, ClickMenuAction, FillAction, SelectAction,
+    TypeAction, PressAction, HoverAction, ScrollToAction, ScrollAction,
+    WaitForAction, HoldAction, DrawAction,
+    Scene, UnifiedSpec, Dimension, Verdict, Decision, NarrationItem,
+    ReviewRequest,
+)
+
+# RunState stays DDD-specific (the converge lifecycle); it composes the
+# neutral Verdict re-exported above.
+<paste the RunState class definition verbatim here, unchanged>
+```
+
+(Copy the real `RunState` class body in place of the placeholder line. If `RunState` referenced any helper that moved, it resolves via the re-exports above.)
+
+- [ ] **Step 3:** Run `uv run pytest`. Expected: **same pass count as Step 0** (all importers resolve through the shim). If `tests/ddd/test_schemas.py` asserts a module path, update the assertion to the new location. Fix any import errors before proceeding.
+
+- [ ] **Step 4: Commit.** `git add scripts/narrative scripts/ddd/schemas/models.py && git commit -m "refactor(narrative): extract generic schemas to scripts/narrative; ddd re-exports + keeps RunState"`
+
+---
+
+## Task 2: Decouple the walkthrough recorder from `ddd`
+
+**Files:**
+- Modify: `scripts/walkthrough/_lib/recorder.py`
+- Modify: `tests/walkthrough/*` that import from `scripts.ddd.schemas.models`
+
+- [ ] **Step 1:** In `scripts/walkthrough/_lib/recorder.py`, change `from scripts.ddd.schemas.models import Action, ACTION_KINDS, …` → `from scripts.narrative.models import Action, ACTION_KINDS, …`. The renderer now depends on the neutral substrate, not the methodology.
+
+- [ ] **Step 2:** Repoint the walkthrough tests that import the action vocabulary (`tests/walkthrough/test_action_kinds_single_source.py`, `test_action_discriminated_union.py`, `test_scene_*`) to `scripts.narrative.models`.
+
+- [ ] **Step 3:** Run `uv run pytest`. Expected: same pass count. **Commit:** `git commit -am "refactor(walkthrough): import Action vocabulary from scripts/narrative, not ddd"`
+
+---
+
+## Task 3: Make the narrative JSON Schema the canonical, published artifact
+
+**Files:**
+- Modify: `scripts/ddd/validate.py` (`dump_json_schemas`) and/or `scripts/ddd/regen_json_schemas.py`
+- Create: `scripts/narrative/schema/json/*.json` (committed artifact)
+- Modify: `.pre-commit-config.yaml` (the `regen-ddd-json-schemas` hook path, if needed)
+
+- [ ] **Step 1:** Point the schema dump at the neutral models and a neutral output dir. In `regen_json_schemas.py`, change `out_dir = REPO_ROOT / "scripts" / "ddd" / "schemas" / "json"` → `REPO_ROOT / "scripts" / "narrative" / "schema" / "json"`, and ensure `dump_json_schemas` enumerates the models from `scripts.narrative.models` (it already imports them transitively via the shim, but make the source explicit). Keep `RunState`'s schema emitted too (DDD still needs it) — either in the same dir or a `scripts/ddd/schemas/json/` for DDD-only models. Decide based on `dump_json_schemas`'s current model list; the goal is **the generic narrative models land under `scripts/narrative/schema/json/` as the canonical contract**.
+
+- [ ] **Step 2:** Run `python scripts/ddd/regen_json_schemas.py`; commit the generated `scripts/narrative/schema/json/*.json`. Update the pre-commit hook's `files:`/output path so the gate tracks the new location.
+
+- [ ] **Step 3:** Run `uv run pytest` + run the pre-commit hook (`pre-commit run regen-ddd-json-schemas --all-files`) to confirm it's clean. **Commit:** `git commit -am "feat(narrative): publish canonical narrative JSON Schema under scripts/narrative/schema/json"`
+
+---
+
+## Task 4 (optional, follow-up): expose validators as a `canopy:narrative` capability
+
+The generic validators (`spec_qa.spec_qa`, `narrative_coherence`, `validate` provenance checks, `why_qa.why_qa`) are already independent `(obj) -> Verdict` functions invocable via `python -m scripts.ddd.<mod>`. ACE can call them today. A thin `plugins/canopy/skills/narrative/SKILL.md` capability (mirroring `visual-judge`) that documents "given a narrative spec, run falsifiability + coherence + provenance + actionability and return Verdicts" makes the reuse explicit. **Out of scope for the core extraction; track separately.**
+
+---
+
+## Done criteria
+- `uv run pytest` pass count unchanged from Step 0 throughout.
+- Generic narrative/eval/review models live in `scripts/narrative/models.py`; `RunState` stays in DDD.
+- The walkthrough recorder imports `Action` from `scripts/narrative`, not `ddd`.
+- Canonical narrative JSON Schema committed under `scripts/narrative/schema/json/`.
+- No `from scripts.ddd.schemas.models import` site broke (re-export shim covers them).
+
+## Downstream (separate, not this plan)
+ACE consumes the published JSON Schema to generate TS types + invokes the canopy validators from its video skills — see `2026-06-07-ace-adopt-narrative-contract.md` (ACE repos).

--- a/docs/superpowers/plans/2026-06-07-workbench-layout-kit.md
+++ b/docs/superpowers/plans/2026-06-07-workbench-layout-kit.md
@@ -1,0 +1,773 @@
+# WorkbenchLayout Kit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a generic, reusable three-pane `WorkbenchLayout` kit (left rail · center · right rail — each collapsible, push or overlay/slide mode) in ace-web, and prove it by re-homing the existing `OppWorkbenchPage` onto it with no functional regression.
+
+**Architecture:** A small dependency-clean module under `frontend/src/components/workbench/` — a generalized collapse hook (`usePaneCollapsed`), a single collapsible rail (`WorkbenchRail`), and the composing layout (`WorkbenchLayout`). Pure presentational, props-in, no ace-web store/domain coupling, so a later cross-repo extraction is trivial. `OppWorkbenchPage` becomes the first consumer: left rail = lifecycle list, center = step detail, right rail = chat.
+
+**Tech Stack:** React 18 + TypeScript, Vite, TailwindCSS (shadcn design tokens: `bg-background`/`bg-card`/`border-border`/`text-muted-foreground`), `lucide-react` icons, Vitest + jsdom + `@testing-library/react`.
+
+**TARGET REPO:** `ace-web` (`/Users/acedimagi/emdash/repositories/ace-web`). This plan doc lives in the `ace` plugin repo as the coordination home; **execute it in an ace-web worktree off `main`** (`git worktree add -b feat/workbench-layout-kit <path> origin/main`). All file paths below are relative to the ace-web repo root.
+
+**Commands:** from `frontend/`: tests `npx vitest run`, type-check `npx tsc -b`, dev `npm run dev`.
+
+---
+
+## File Structure
+
+- Create: `frontend/src/components/workbench/usePaneCollapsed.ts` — localStorage-persisted collapse state, keyed per pane.
+- Create: `frontend/src/components/workbench/WorkbenchRail.tsx` — one collapsible side rail (left or right; push or overlay mode).
+- Create: `frontend/src/components/workbench/WorkbenchLayout.tsx` — composes header + optional toolbar + left/center/right.
+- Create: `frontend/src/components/workbench/index.ts` — barrel export (the kit's public surface).
+- Create: `frontend/src/components/workbench/README.md` — the three-pane contract (so future UIs + an eventual canopy-web migration conform).
+- Create: `frontend/src/components/workbench/__tests__/usePaneCollapsed.test.tsx`
+- Create: `frontend/src/components/workbench/__tests__/WorkbenchRail.test.tsx`
+- Create: `frontend/src/components/workbench/__tests__/WorkbenchLayout.test.tsx`
+- Modify: `frontend/src/pages/OppWorkbenchPage.tsx` (replace the inline 3-pane markup in the `view === "workbench"` block with `<WorkbenchLayout>`; swap `useChatPaneCollapsed` for `usePaneCollapsed`).
+- Reference (do not modify): `frontend/src/hooks/useChatPaneCollapsed.ts` (the pattern being generalized — leave it; OppWorkbenchPage stops importing it).
+
+**Intentional UX change (not a regression):** today `OppWorkbenchPage`'s lifecycle list grows (`flex-1`) when the chat is open and the detail pane is fixed; in the canonical kit the **center detail always grows** and both side rails are fixed-width + collapsible. This is the deliberate move to the left-rail/center/right-rail model (the target design), not an accidental behavior change. Call it out in the refactor commit.
+
+---
+
+## Task 1: `usePaneCollapsed` hook
+
+Generalizes `useChatPaneCollapsed` to any pane via a storage key.
+
+**Files:**
+- Create: `frontend/src/components/workbench/usePaneCollapsed.ts`
+- Test: `frontend/src/components/workbench/__tests__/usePaneCollapsed.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/workbench/__tests__/usePaneCollapsed.test.tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { usePaneCollapsed } from "../usePaneCollapsed";
+
+describe("usePaneCollapsed", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("defaults to false and toggles", () => {
+    const { result } = renderHook(() => usePaneCollapsed("test.key"));
+    expect(result.current.collapsed).toBe(false);
+    act(() => result.current.toggle());
+    expect(result.current.collapsed).toBe(true);
+  });
+
+  it("honors the defaultCollapsed argument when storage is empty", () => {
+    const { result } = renderHook(() => usePaneCollapsed("test.key2", true));
+    expect(result.current.collapsed).toBe(true);
+  });
+
+  it("persists to localStorage under the given key", () => {
+    const { result } = renderHook(() => usePaneCollapsed("test.persist"));
+    act(() => result.current.setCollapsed(true));
+    expect(window.localStorage.getItem("test.persist")).toBe("1");
+  });
+
+  it("reads an existing stored value over the default", () => {
+    window.localStorage.setItem("test.read", "1");
+    const { result } = renderHook(() => usePaneCollapsed("test.read", false));
+    expect(result.current.collapsed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `frontend/`): `npx vitest run src/components/workbench/__tests__/usePaneCollapsed.test.tsx`
+Expected: FAIL — `Cannot find module '../usePaneCollapsed'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// frontend/src/components/workbench/usePaneCollapsed.ts
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * localStorage-persisted collapse state for a workbench pane, keyed per
+ * pane so multiple rails on one page don't collide. Generalized from
+ * hooks/useChatPaneCollapsed.ts. Falls back to per-tab state when storage
+ * is unavailable (private mode).
+ */
+export function usePaneCollapsed(
+  storageKey: string,
+  defaultCollapsed = false,
+): { collapsed: boolean; toggle: () => void; setCollapsed: (v: boolean) => void } {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return defaultCollapsed;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (raw === null) return defaultCollapsed;
+      return raw === "1";
+    } catch {
+      return defaultCollapsed;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, collapsed ? "1" : "0");
+    } catch {
+      // storage disabled — preference is per-tab only
+    }
+  }, [storageKey, collapsed]);
+
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+
+  return { collapsed, toggle, setCollapsed };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/workbench/__tests__/usePaneCollapsed.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/workbench/usePaneCollapsed.ts frontend/src/components/workbench/__tests__/usePaneCollapsed.test.tsx
+git commit -m "feat(workbench): usePaneCollapsed — generalized per-key collapse hook"
+```
+
+---
+
+## Task 2: `WorkbenchRail` — collapsible side rail (push mode)
+
+One rail that renders its content (expanded) or a thin icon strip (collapsed), for either side. Width animates (the "slide").
+
+**Files:**
+- Create: `frontend/src/components/workbench/WorkbenchRail.tsx`
+- Test: `frontend/src/components/workbench/__tests__/WorkbenchRail.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/workbench/__tests__/WorkbenchRail.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { WorkbenchRail } from "../WorkbenchRail";
+
+describe("WorkbenchRail", () => {
+  it("renders title + content when expanded", () => {
+    render(
+      <WorkbenchRail side="right" title="Chat" collapsed={false} onToggle={() => {}}>
+        <div>pane body</div>
+      </WorkbenchRail>,
+    );
+    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getByText("pane body")).toBeInTheDocument();
+  });
+
+  it("hides content and shows the expand affordance when collapsed", () => {
+    render(
+      <WorkbenchRail side="right" title="Chat" collapsed onToggle={() => {}}>
+        <div>pane body</div>
+      </WorkbenchRail>,
+    );
+    expect(screen.queryByText("pane body")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show chat/i })).toBeInTheDocument();
+  });
+
+  it("calls onToggle when the collapse button is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <WorkbenchRail side="right" title="Chat" collapsed={false} onToggle={onToggle}>
+        <div>pane body</div>
+      </WorkbenchRail>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /hide chat/i }));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/workbench/__tests__/WorkbenchRail.test.tsx`
+Expected: FAIL — `Cannot find module '../WorkbenchRail'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// frontend/src/components/workbench/WorkbenchRail.tsx
+import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export type RailSide = "left" | "right";
+export type RailMode = "push" | "overlay";
+
+export interface WorkbenchRailProps {
+  children: ReactNode;
+  /** Which edge the rail sits on (controls border + chevron direction). */
+  side: RailSide;
+  /** Short label shown in the expanded rail's header + aria labels. */
+  title: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  /** Expanded width in px. Default 400. */
+  expandedWidth?: number;
+  /** Width of the collapsed icon strip in px. Default 32. */
+  collapsedWidth?: number;
+  /** "push" (default) reflows the center; "overlay" floats over it (Task 4). */
+  mode?: RailMode;
+}
+
+// Chevron that points "outward" to expand and "inward" to collapse,
+// mirrored per side. Right rail: collapse = ChevronRight, expand = ChevronLeft.
+function railChevron(side: RailSide, action: "collapse" | "expand") {
+  const pointsRight =
+    (side === "right" && action === "collapse") ||
+    (side === "left" && action === "expand");
+  return pointsRight ? ChevronRight : ChevronLeft;
+}
+
+export function WorkbenchRail({
+  children,
+  side,
+  title,
+  collapsed,
+  onToggle,
+  expandedWidth = 400,
+  collapsedWidth = 32,
+}: WorkbenchRailProps) {
+  const borderClass = side === "left" ? "border-r" : "border-l";
+
+  if (collapsed) {
+    const Expand = railChevron(side, "expand");
+    return (
+      <aside
+        className={`flex shrink-0 flex-col items-center ${borderClass} border-border bg-card transition-[width] duration-150`}
+        style={{ width: collapsedWidth }}
+      >
+        <button
+          type="button"
+          onClick={onToggle}
+          className="mt-2 flex h-8 w-8 items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+          title={`Show ${title} pane`}
+          aria-label={`Show ${title} pane`}
+          aria-expanded="false"
+        >
+          <Expand className="h-4 w-4" />
+        </button>
+      </aside>
+    );
+  }
+
+  const Collapse = railChevron(side, "collapse");
+  return (
+    <aside
+      className={`flex shrink-0 flex-col ${borderClass} border-border bg-card transition-[width] duration-150`}
+      style={{ width: expandedWidth }}
+    >
+      <div className="flex items-center justify-between border-b border-border px-2 py-1">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          {title}
+        </span>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+          title={`Hide ${title} pane`}
+          aria-label={`Hide ${title} pane`}
+          aria-expanded="true"
+        >
+          <Collapse className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/workbench/__tests__/WorkbenchRail.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/workbench/WorkbenchRail.tsx frontend/src/components/workbench/__tests__/WorkbenchRail.test.tsx
+git commit -m "feat(workbench): WorkbenchRail — collapsible left/right rail (push mode)"
+```
+
+---
+
+## Task 3: `WorkbenchLayout` — compose the three panes
+
+**Files:**
+- Create: `frontend/src/components/workbench/WorkbenchLayout.tsx`
+- Test: `frontend/src/components/workbench/__tests__/WorkbenchLayout.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/workbench/__tests__/WorkbenchLayout.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WorkbenchLayout } from "../WorkbenchLayout";
+
+describe("WorkbenchLayout", () => {
+  it("renders header, toolbar and center", () => {
+    render(
+      <WorkbenchLayout
+        header={<div>HEADER</div>}
+        toolbar={<div>TABS</div>}
+        center={<div>CENTER</div>}
+      />,
+    );
+    expect(screen.getByText("HEADER")).toBeInTheDocument();
+    expect(screen.getByText("TABS")).toBeInTheDocument();
+    expect(screen.getByText("CENTER")).toBeInTheDocument();
+  });
+
+  it("renders left and right rails when provided", () => {
+    render(
+      <WorkbenchLayout
+        center={<div>CENTER</div>}
+        left={{ title: "Nav", collapsed: false, onToggle: () => {}, content: <div>LEFT</div> }}
+        right={{ title: "Inspector", collapsed: false, onToggle: () => {}, content: <div>RIGHT</div> }}
+      />,
+    );
+    expect(screen.getByText("LEFT")).toBeInTheDocument();
+    expect(screen.getByText("RIGHT")).toBeInTheDocument();
+    expect(screen.getByText("Nav")).toBeInTheDocument();
+    expect(screen.getByText("Inspector")).toBeInTheDocument();
+  });
+
+  it("omits rails that are not provided", () => {
+    render(<WorkbenchLayout center={<div>CENTER</div>} />);
+    expect(screen.queryByText("LEFT")).not.toBeInTheDocument();
+    expect(screen.queryByText("RIGHT")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/workbench/__tests__/WorkbenchLayout.test.tsx`
+Expected: FAIL — `Cannot find module '../WorkbenchLayout'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// frontend/src/components/workbench/WorkbenchLayout.tsx
+import type { ReactNode } from "react";
+import { WorkbenchRail, type RailMode } from "./WorkbenchRail";
+
+export interface WorkbenchRailConfig {
+  content: ReactNode;
+  title: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  expandedWidth?: number;
+  collapsedWidth?: number;
+  mode?: RailMode;
+}
+
+export interface WorkbenchLayoutProps {
+  /** Sticky header slot (e.g. WorkbenchHeader with the run picker). */
+  header?: ReactNode;
+  /** Optional toolbar under the header (e.g. ViewSwitcher tabs). */
+  toolbar?: ReactNode;
+  /** Left rail — the entity navigator (lifecycle / narrative+runs). */
+  left?: WorkbenchRailConfig;
+  /** Center detail canvas. Always grows to fill remaining width. */
+  center: ReactNode;
+  /** Right rail — the inspector / chat. */
+  right?: WorkbenchRailConfig;
+  className?: string;
+}
+
+/**
+ * Generic three-pane workbench shell: [left rail | center | right rail].
+ * Each rail is independently collapsible (push mode here; overlay in
+ * WorkbenchRail Task 4). Center always flex-grows. Pure presentational —
+ * pass collapse state in via usePaneCollapsed. See README.md for the
+ * three-pane contract.
+ */
+export function WorkbenchLayout({
+  header,
+  toolbar,
+  left,
+  center,
+  right,
+  className,
+}: WorkbenchLayoutProps) {
+  return (
+    <div className={`flex h-full flex-col bg-background text-foreground ${className ?? ""}`}>
+      {header}
+      {toolbar}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {left ? (
+          <WorkbenchRail
+            side="left"
+            title={left.title}
+            collapsed={left.collapsed}
+            onToggle={left.onToggle}
+            expandedWidth={left.expandedWidth}
+            collapsedWidth={left.collapsedWidth}
+            mode={left.mode}
+          >
+            {left.content}
+          </WorkbenchRail>
+        ) : null}
+        <main className="min-h-0 flex-1 overflow-y-auto">{center}</main>
+        {right ? (
+          <WorkbenchRail
+            side="right"
+            title={right.title}
+            collapsed={right.collapsed}
+            onToggle={right.onToggle}
+            expandedWidth={right.expandedWidth}
+            collapsedWidth={right.collapsedWidth}
+            mode={right.mode}
+          >
+            {right.content}
+          </WorkbenchRail>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/workbench/__tests__/WorkbenchLayout.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/workbench/WorkbenchLayout.tsx frontend/src/components/workbench/__tests__/WorkbenchLayout.test.tsx
+git commit -m "feat(workbench): WorkbenchLayout — three-pane shell composing rails + center"
+```
+
+---
+
+## Task 4: Overlay / slide-over mode for `WorkbenchRail`
+
+Adds the configurable "slide-in/slide-out" mode: instead of reflowing the center, the rail floats over it and slides via transform. Selected per-rail with `mode="overlay"`.
+
+**Files:**
+- Modify: `frontend/src/components/workbench/WorkbenchRail.tsx`
+- Test: `frontend/src/components/workbench/__tests__/WorkbenchRail.test.tsx` (add cases)
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `WorkbenchRail.test.tsx`:
+
+```tsx
+describe("WorkbenchRail overlay mode", () => {
+  it("keeps content mounted but translated off-canvas when collapsed", () => {
+    render(
+      <WorkbenchRail
+        side="right" title="Inspector" mode="overlay" collapsed onToggle={() => {}}
+      >
+        <div>overlay body</div>
+      </WorkbenchRail>,
+    );
+    // In overlay mode the body stays mounted (so its state survives a
+    // slide-out) — it is hidden via transform/aria, not unmounted.
+    const region = screen.getByRole("complementary", { hidden: true });
+    expect(region).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText("overlay body")).toBeInTheDocument();
+  });
+
+  it("is visible (aria-hidden false) when expanded in overlay mode", () => {
+    render(
+      <WorkbenchRail
+        side="right" title="Inspector" mode="overlay" collapsed={false} onToggle={() => {}}
+      >
+        <div>overlay body</div>
+      </WorkbenchRail>,
+    );
+    expect(screen.getByRole("complementary")).toHaveAttribute("aria-hidden", "false");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify the new cases fail**
+
+Run: `npx vitest run src/components/workbench/__tests__/WorkbenchRail.test.tsx`
+Expected: FAIL on the two overlay cases (push mode unmounts/has no `complementary` role with aria-hidden).
+
+- [ ] **Step 3: Implement overlay mode**
+
+Replace the body of `WorkbenchRail` so it branches on `mode`. Keep the existing push branch; add an overlay branch BEFORE it:
+
+```tsx
+// inside WorkbenchRail(), after destructuring props and computing borderClass:
+  if (mode === "overlay") {
+    const Collapse = railChevron(side, "collapse");
+    const Expand = railChevron(side, "expand");
+    const edge = side === "left" ? "left-0" : "right-0";
+    const hiddenTransform =
+      side === "left" ? "translateX(-100%)" : "translateX(100%)";
+    return (
+      <>
+        {/* Persistent edge trigger so a fully slid-out rail can be reopened. */}
+        {collapsed ? (
+          <aside
+            className={`flex shrink-0 flex-col items-center ${borderClass} border-border bg-card`}
+            style={{ width: collapsedWidth }}
+          >
+            <button
+              type="button"
+              onClick={onToggle}
+              className="mt-2 flex h-8 w-8 items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+              title={`Show ${title} pane`}
+              aria-label={`Show ${title} pane`}
+            >
+              <Expand className="h-4 w-4" />
+            </button>
+          </aside>
+        ) : null}
+        <aside
+          role="complementary"
+          aria-hidden={collapsed ? "true" : "false"}
+          className={`absolute top-0 ${edge} z-20 flex h-full flex-col ${borderClass} border-border bg-card shadow-lg transition-transform duration-150`}
+          style={{
+            width: expandedWidth,
+            transform: collapsed ? hiddenTransform : "translateX(0)",
+          }}
+        >
+          <div className="flex items-center justify-between border-b border-border px-2 py-1">
+            <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              {title}
+            </span>
+            <button
+              type="button"
+              onClick={onToggle}
+              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              title={`Hide ${title} pane`}
+              aria-label={`Hide ${title} pane`}
+            >
+              <Collapse className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+        </aside>
+      </>
+    );
+  }
+```
+
+Note: overlay positioning is relative to the nearest positioned ancestor. In `WorkbenchLayout`, add `relative` to the panes row so the overlay anchors correctly — change `<div className="flex min-h-0 flex-1 overflow-hidden">` to `<div className="relative flex min-h-0 flex-1 overflow-hidden">` in `WorkbenchLayout.tsx`.
+
+- [ ] **Step 4: Run to verify all WorkbenchRail tests pass**
+
+Run: `npx vitest run src/components/workbench/__tests__/WorkbenchRail.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/workbench/WorkbenchRail.tsx frontend/src/components/workbench/WorkbenchLayout.tsx frontend/src/components/workbench/__tests__/WorkbenchRail.test.tsx
+git commit -m "feat(workbench): configurable overlay/slide-over rail mode"
+```
+
+---
+
+## Task 5: Barrel export + contract README
+
+**Files:**
+- Create: `frontend/src/components/workbench/index.ts`
+- Create: `frontend/src/components/workbench/README.md`
+
+- [ ] **Step 1: Write the barrel**
+
+```ts
+// frontend/src/components/workbench/index.ts
+export { WorkbenchLayout } from "./WorkbenchLayout";
+export type { WorkbenchLayoutProps, WorkbenchRailConfig } from "./WorkbenchLayout";
+export { WorkbenchRail } from "./WorkbenchRail";
+export type { WorkbenchRailProps, RailSide, RailMode } from "./WorkbenchRail";
+export { usePaneCollapsed } from "./usePaneCollapsed";
+```
+
+- [ ] **Step 2: Write the contract README**
+
+```md
+# WorkbenchLayout kit
+
+Generic three-pane workbench shell: **[ left rail | center | right rail ]**.
+Each rail is independently collapsible (`push` reflows the center; `overlay`
+slides over it). Center always grows. Pure presentational — pass collapse
+state in via `usePaneCollapsed(storageKey, default)`.
+
+## Contract (future UIs + an eventual canopy-web migration conform to this)
+- **Left rail** = the entity navigator: the list you select from (lifecycle
+  steps / narrative beats + runs). Collapsible.
+- **Center** = the detail canvas for the selected entity. Always flex-grows.
+- **Right rail** = the inspector / chat / edit surface for the selection.
+- **Header** slot holds the run picker; **toolbar** slot holds view tabs.
+
+## Usage
+```tsx
+const left = usePaneCollapsed("ace.video.navCollapsed");
+const right = usePaneCollapsed("ace.video.inspectorCollapsed");
+<WorkbenchLayout
+  header={<MyHeader />}
+  toolbar={<MyTabs />}
+  left={{ title: "Narrative", collapsed: left.collapsed, onToggle: left.toggle, content: <NavRail/> }}
+  center={<DetailPane/>}
+  right={{ title: "Inspector", collapsed: right.collapsed, onToggle: right.toggle, content: <Inspector/>, mode: "overlay" }}
+/>
+```
+
+## Boundary
+No app/store/domain imports — props in only — so this is cheap to extract
+into a shared cross-repo package when a second app (canopy-web) adopts it.
+```
+
+- [ ] **Step 3: Run the full kit test suite + type-check**
+
+Run: `npx vitest run src/components/workbench/` then `npx tsc -b`
+Expected: all kit tests PASS; tsc clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/workbench/index.ts frontend/src/components/workbench/README.md
+git commit -m "docs(workbench): barrel export + three-pane contract README"
+```
+
+---
+
+## Task 6: Re-home `OppWorkbenchPage` onto `WorkbenchLayout`
+
+Prove the kit on the real, battle-tested consumer. Map: **left rail = `SkillList`**, **center = `StepDetailPane`/EmptyState**, **right rail = `WorkbenchChatPane`**.
+
+**Files:**
+- Modify: `frontend/src/pages/OppWorkbenchPage.tsx`
+
+- [ ] **Step 1: Capture the baseline**
+
+Run: `npx vitest run` (note the pass count) and `npx tsc -b` (note clean). Then `npm run dev`, open an opp workbench, and confirm current behavior (3 panes, chat collapse toggles). This is the regression reference.
+
+- [ ] **Step 2: Swap the collapse hook**
+
+In `OppWorkbenchPage.tsx`, replace the import + call:
+
+```tsx
+// remove:
+import { useChatPaneCollapsed } from "../hooks/useChatPaneCollapsed";
+// add:
+import { usePaneCollapsed } from "../components/workbench";
+
+// remove:
+//   const { collapsed: chatCollapsed, toggle: toggleChatCollapsed } = useChatPaneCollapsed();
+// add (preserve the existing storage key so the user's saved preference carries over):
+const { collapsed: chatCollapsed, toggle: toggleChatCollapsed } = usePaneCollapsed(
+  "ace.workbench.chatPaneCollapsed",
+);
+const { collapsed: navCollapsed, toggle: toggleNavCollapsed } = usePaneCollapsed(
+  "ace.workbench.navPaneCollapsed",
+);
+```
+
+- [ ] **Step 3: Replace the `view === "workbench"` markup**
+
+Replace the entire `{view === "workbench" && ( … )}` block (the `<>` containing the inline `flex flex-1` panes + the `<main>/<section>/<aside>` markup) with:
+
+```tsx
+{view === "workbench" && (
+  <WorkbenchLayout
+    left={{
+      title: "Lifecycle",
+      collapsed: navCollapsed,
+      onToggle: toggleNavCollapsed,
+      expandedWidth: 440,
+      content: (
+        <SkillList
+          steps={snapshot.current_run.steps}
+          priorRunSteps={[]}
+          phases={snapshot.phases}
+          selectedSkill={selectedSkill}
+          onSelect={setSelectedSkill}
+          costRollup={costRollup}
+        />
+      ),
+    }}
+    center={
+      selectedStep ? (
+        <StepDetailPane
+          workspaceSlug={workspaceSlug ?? ""}
+          slug={slug}
+          runId={snapshot.current_run.run_id}
+          skill={selectedStep.skill_name}
+          skillDisplayName={selectedStep.display_name}
+        />
+      ) : (
+        <EmptyState
+          title="Select a step"
+          description="Click a row in the lifecycle to see its details."
+        />
+      )
+    }
+    right={{
+      title: "Chat",
+      collapsed: chatCollapsed,
+      onToggle: toggleChatCollapsed,
+      expandedWidth: 400,
+      content: selectedStep ? (
+        <WorkbenchChatPane
+          slug={slug}
+          runId={snapshot.current_run.run_id}
+          skill={selectedStep.skill_name}
+          skillDisplayName={selectedStep.display_name}
+        />
+      ) : (
+        <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted-foreground">
+          Select a step in the lifecycle to see its chats
+        </div>
+      ),
+    }}
+  />
+)}
+```
+
+Add the import at the top: `import { WorkbenchLayout, usePaneCollapsed } from "../components/workbench";` (and remove the now-unused `ChevronLeft, ChevronRight` import if nothing else uses it — check the file first; `grep -n "Chevron" frontend/src/pages/OppWorkbenchPage.tsx`).
+
+Note: the outer `<div className="flex h-full flex-col …">` and `WorkbenchHeader` + `ViewSwitcher` stay OUTSIDE `WorkbenchLayout` (the page keeps its own header/tabs since other views — phase/heatmap/diff — share them). Only the workbench *view* uses `WorkbenchLayout`'s center/rails; pass `header`/`toolbar` as `undefined` here. (A later cleanup can move header+tabs into the layout's slots once all views are migrated — out of scope.)
+
+- [ ] **Step 4: Type-check + full test suite (regression gate)**
+
+Run: `npx tsc -b` then `npx vitest run`
+Expected: tsc clean; test count = baseline from Step 1 (no test deletions, no new failures).
+
+- [ ] **Step 5: Manual regression check**
+
+Run `npm run dev`, open an opp workbench. Verify: left lifecycle rail (collapsible via its header chevron), center step detail grows, right chat rail collapses to the icon strip, saved chat-collapse preference still honored (`ace.workbench.chatPaneCollapsed`). Confirm phase/heatmap/diff tabs still render.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/OppWorkbenchPage.tsx
+git commit -m "refactor(opps): re-home OppWorkbench onto WorkbenchLayout kit (left rail = lifecycle, center = detail, right rail = chat)"
+```
+
+---
+
+## Self-Review checklist (run before opening the PR)
+
+- [ ] **Spec coverage:** kit provides left/center/right (Task 3), each collapsible (Tasks 2/3) in push + overlay/slide modes (Task 4), proven by the OppWorkbench refactor (Task 6) — matches spec §5 decisions 3–4 and §7 inventory (the run-picker/`ViewSwitcher` stay as caller-provided `header`/`toolbar` slots; edit-op engine + atoms are deferred to Stage 5 per spec §7).
+- [ ] **No regression:** Task 6 Step 4 asserts the full-suite count is unchanged and tsc clean; Step 5 is the manual gate.
+- [ ] **Type consistency:** `WorkbenchRailConfig.content` (object form, used by `WorkbenchLayout`) vs `WorkbenchRailProps.children` (component form, used by `WorkbenchRail` directly) — intentional and consistent across Tasks 2–3.
+- [ ] **Storage-key continuity:** Task 6 reuses `"ace.workbench.chatPaneCollapsed"` so existing user prefs carry over; the new left rail uses a fresh key.
+- [ ] Open a PR to `jjackson/ace-web`; the new `videos`/`CI` checks must pass (note: the kit is `frontend/`, gated by the build/tsc path, not the connect-videos `videos.yml`).
+
+---
+
+## Next plans (not this plan)
+
+- **Plan 2 — Narrative substrate extraction (canopy)** — lift `WhyBrief`/evidence/`Gap`/decomposition/`Verdict` + validators out of `scripts.ddd` into a neutral module + `canopy:narrative`; DDD re-points imports. Spec §6 Stage 2.
+- **Stage 5 — Video review surface** on this kit (left rail = narrative + runs; center = beat/scene detail; right = inspector) — after Plan 2 + Stage 3.

--- a/docs/superpowers/specs/2026-06-07-video-narrative-workbench-substrate.md
+++ b/docs/superpowers/specs/2026-06-07-video-narrative-workbench-substrate.md
@@ -1,0 +1,110 @@
+# Video Narrative + Workbench Substrate — Design Spec
+
+**Date:** 2026-06-07
+**Status:** Approved direction, plans in progress
+**Spans:** `ace-web` (frontend + apps/videos), `ace` plugin (video skills), `canopy` (DDD substrate), `canopy-web` (review package)
+
+---
+
+## 1. North star
+
+The ACE video-creation system and canopy's `ddd` (demo-driven-development) system are **the same machine**: author a narrative → decompose it into typed parts → run it → eval each part → publish a reviewable package. DDD has pushed three of those further than the video work, and the video work should adopt them — **reusing canopy's substrate where it's generic, keeping ACE/Connect specifics in ACE.**
+
+The three things DDD does that the video pipeline is missing:
+
+1. **The narrative as a first-class, structured, judgeable object** — not implicit in beats + prose.
+2. **Reasoning about which parts exist vs. are missing** — evidence classification (`documented | implemented | assumed`) + typed Gaps (`RESEARCH | CAPABILITY | DECISION`).
+3. **A reviewable run-package UI that makes an AI artifact's uncertainty legible.**
+
+Lineage note: DDD was itself built by examining the ACE video work; canopy-web's review editor's own comments say it mirrors ace-web's `videos/types.ts`. This is bidirectional cross-pollination — which strengthens the case for a shared substrate, carefully bounded.
+
+## 2. Architecture: three layers
+
+```
+ORCHESTRATORS (thin; methodology/domain)
+  canopy:ddd  (product demos)        ACE: partnership-video / connect-explainer (Connect marketing videos)
+        │                                       │
+        └──────────── both consume ─────────────┘
+                          ▼
+SUBSTRATE (canopy, generic)
+  • narrative object + mechanical decomposition (narrative → parts)
+  • evidence model (documented|implemented|assumed) + typed Gaps (RESEARCH|CAPABILITY|DECISION)
+  • Verdict + QA-gates-Eval + visual-judge
+  • run-package + hero-artifact (canopy-web ReviewRequest / Walkthrough)
+                          │
+            drive a pluggable RENDERER
+                          ▼
+RENDERERS (siblings)
+  canopy:walkthrough (web screen-record)   ace-web:connect-videos (Remotion clip composite)
+  [canopy]                                  [ace-web — stays ACE]
+```
+
+## 3. What canopy already separated (the audit that shaped this)
+
+| Layer | State | Where |
+|---|---|---|
+| Render capability (`canopy:walkthrough`) | ✅ clean standalone; DDD reuses by spec-compatibility | `canopy plugins/canopy/skills/walkthrough` |
+| Eval harness (`visual-judge` + `Verdict`) | ✅ extracted, rubric-driven, namespace-neutral; **ACE Phase 6 already calls visual-judge** | `Verdict` in `scripts/ddd/schemas/models.py` |
+| Web run-package + hero artifact (`ReviewRequest` + `Walkthrough`) | ✅ storage fully generic (opaque `request_json`); `Walkthrough` already `kind=video` | `canopy-web apps/reviews`, `apps/walkthroughs` |
+| Narrative / evidence-gap / decomposition / converge-loop | ❌ **welded** inside `scripts.ddd`; no neutral `lib/` | `canopy scripts/ddd/{schemas/models.py, validate.py, narrative_coherence.py, run_pipeline.py}` |
+
+**Load-bearing fact:** canopy has **no clip-based (Remotion) renderer** — its only "video" is Playwright screen-recording → mp4. ACE's `connect-videos` Remotion engine is a *different renderer* and **stays ACE-side**. The two renderers are siblings that both plug into the substrate, exactly as `walkthrough` does today.
+
+## 4. What goes where (the "generic → canopy, specific → ACE" rule applied)
+
+**To canopy (generic substrate):**
+- The narrative object, mechanical decomposition contract, evidence/gap model, and pure validators (falsifiability/banned-phrase, provenance-resolution, outcome-leakage, actionability cold-derive) — **extracted out of `scripts.ddd`** into a neutral module.
+- The `Verdict` schema + QA-gates-Eval contract (lift out of `scripts.ddd.schemas`).
+- `canopy-web` review-package generalization (so a video run renders as a package).
+
+**Stays ACE / ace-web (specific):**
+- The Remotion `connect-videos` renderer + Connect templates/brand.
+- Partnership research / Connect-fit grounding, prospect-branding overlay.
+- The video review **UI itself** (in ace-web), built on a shared `WorkbenchLayout` kit.
+
+## 4b. Cross-language: shared contract, not shared code
+
+Both ecosystems are polyglot (Python backends + DDD engine; TS frontends, MCP, and the Remotion renderer; Markdown skills as glue). The substrate is therefore shared as a **canonical contract**, not a shared import:
+
+- **Canonical home = Python/pydantic in canopy** (`scripts/ddd` → `scripts/narrative`). pydantic dumps **JSON Schema for free** (canopy already does this via `scripts/ddd/regen_json_schemas.py` → `scripts.ddd.validate.dump_json_schemas`, committed + pre-commit-gated). That JSON Schema is the single source of truth.
+- **Python consumers import it** — canopy DDD, canopy-web Django, ace-web Django (`apps/videos`).
+- **TypeScript consumers generate types from the JSON Schema** — ace-web frontend already runs `openapi-typescript` (`gen:api`). `lib/verdict-schema.ts` becomes **generated**, not hand-maintained (kills the existing drift).
+- **Claude skill orchestrators invoke the Python validators via CLI** — exactly how `ddd-*` skills already do (`uv run python -m scripts.ddd.spec_qa …`) and how ACE already calls `canopy:visual-judge`. "Orchestrate on top, like walkthrough." No Python imported into TS.
+- **Only exception:** a validator that must run *in-process inside the Remotion/TS render pipeline* gets a TS implementation tested against **shared fixtures** generated from the Python side, so the two can't silently diverge.
+
+Best-tool-per-layer holds: Python owns the schema + validators; TS surfaces get generated types; Markdown skills glue via CLI + capability invocation.
+
+## 5. Locked decisions
+
+1. **Refactor canopy** to extract the narrative/evidence-gap/decomposition/Verdict substrate out of `scripts.ddd` into a neutral module + a thin `canopy:narrative` capability skill (mirrors how `walkthrough` is a capability + `scripts/walkthrough/`). DDD becomes an orchestrator on top — re-points imports, behavior unchanged, tests stay green.
+2. **Renderers stay siblings.** `connect-videos` stays in ace-web as ACE's renderer; do **not** move the Remotion engine into canopy. Formalize a renderer contract only once two renderers consume the substrate (later stage).
+3. **The video review UI lives in ace-web**, built on a reusable **`WorkbenchLayout`** kit.
+4. **`WorkbenchLayout` is a generic ace-web library** — left rail / center pane / right rail, every pane independently collapsible and slide-in/out configurable. It is **proven by refactoring the existing `OppWorkbenchPage` onto it first** (a real second consumer already exists — the opp workbench and the video editor are divergent copies of this pattern today). Build it props-in / dependency-clean so a future cross-repo extraction is cheap.
+5. **Cross-repo UI sharing is a later, separate question.** Both apps already have left-rail shells (`AppLayout` in canopy-web, the workbench in ace-web). Converging them across two SPAs has real infra cost and earns its keep only once the ace-web kit is clean and a concrete canopy-web migration is on the table. The immediate, high-value consolidation is **intra-ace-web** (opp workbench ↔ video).
+
+## 6. Staged plan (each stage = its own implementation plan)
+
+- **Stage 1 — `WorkbenchLayout` kit (ace-web).** Extract a generic 3-pane (left/center/right, each collapsible + slide-configurable) layout from `OppWorkbenchPage`; re-home the opp workbench onto it (no regression); set up the slots video review will use. **Lead plan — `docs/superpowers/plans/2026-06-07-workbench-layout-kit.md`. Self-contained, no canopy dependency.**
+- **Stage 2 — Narrative substrate extraction (canopy).** Lift `WhyBrief` / evidence / `Gap` / decomposition / provenance / `Verdict` + validators out of `scripts.ddd` into a neutral module + `canopy:narrative` capability; DDD re-points imports; canopy tests stay green. **Plan 2 — to be written. Self-contained refactor.**
+- **Stage 3 — ACE video adopts the narrative substrate.** Promote `partnership-narratives` to a first-class structured narrative the renderer + UI consume; add the evidence/gap layer (generalize "no inferred backstory" → classified evidence + typed gaps); adopt narrative-first mechanical decomposition. Depends on Stage 2.
+- **Stage 4 — ACE video adopts the eval substrate.** Per-beat `visual-judge` on rendered frames; narrative-coherence/outcome-leakage + actionability cold-derive on video narration; a narrative-review human gate before render. Depends on Stage 2.
+- **Stage 5 — Reviewable video run-package.** Build the video review surface in ace-web on the Stage 1 `WorkbenchLayout` (left rail = narrative + runs; center = beat/scene detail; right = inspector). Generalize canopy-web's `ReviewRequest` dashboard derivation if/when a shared package surface is wanted. Depends on Stages 1 + 3.
+- **Stage 6 (later) — Formalize the renderer contract** + evaluate cross-repo extraction of `WorkbenchLayout` into a shared package, gated on a concrete canopy-web need.
+
+## 7. Reusable primitives inventory (what Stage 1's kit contains)
+
+Lifted from the battle-tested `OppWorkbenchPage`; domain content plugs into slots.
+
+- **`WorkbenchLayout`** — header slot + N panes (left/center/right), each collapsible with the `w-[…]`/`shrink-0`/`border-l`/collapse-to-icon-strip mechanics already in `OppWorkbenchPage`, plus slide-in/out config.
+- **`usePaneCollapsed(storageKey, default)`** — generalized from `useChatPaneCollapsed` (localStorage-persisted collapse).
+- **Run picker / runs strip** — generic (`RunSelector` is already just runs).
+- **Left "entity rail" scaffold** — today `SkillList`; for video the narrative→beats list.
+- **Detail-pane + inspector-rail scaffolds, `EmptyState`, `ViewSwitcher`.**
+- **Edit-op engine + atoms** (`ScoreBadge` / `StatusBadge` / `PersonaChip`) — ace-web `videos/types.ts` and canopy-web `reviewApplyOps.ts` are already divergent copies; strongest dedupe candidate (deferred to Stage 5).
+
+## 8. Risks / watch-items
+
+- **Premature cross-repo packaging.** Mitigation: build `WorkbenchLayout` extraction-ready but keep it in ace-web until a 2nd repo consumer is real (decision §5).
+- **DDD rubrics are uncalibrated** ("provisional; calibrate via defect-creator after 3 runs"). When ACE adopts the eval substrate (Stage 4), steal canopy's `walkthrough-defect-creator` calibration harness alongside the rubrics — don't trust absolute thresholds yet.
+- **Substrate extraction touching DDD mid-flight.** Mitigation: Stage 2 is a pure refactor with canopy's existing tests as the regression guard; no behavior change.
+- **Two ace-web sessions in parallel** (this initiative + the core-video-creation session) both bump ace-web VERSION. Mitigation: separate worktrees/branches; expect version-collision; this initiative touches `frontend/` + (later) `apps/videos` review surface, the other touches `apps/videos` ops + `video-production`.


### PR DESCRIPTION
Cross-repo design for sharing canopy's DDD narrative/eval substrate with the ACE video pipeline.

- **Spec** `docs/superpowers/specs/2026-06-07-video-narrative-workbench-substrate.md` — 3-layer architecture (substrate / orchestrators / renderers), the canopy reuse audit, the cross-language contract decision (canonical Python schema → generated TS types → skill-invoked validators), and the staged sequence.
- **Plan 1** `…-workbench-layout-kit.md` — generic `WorkbenchLayout` kit (left/center/right, collapsible + slide-configurable) extracted from `OppWorkbenchPage`, proven by re-homing the opp workbench. ace-web; no dependencies.
- **Plan 2** `…-canopy-narrative-substrate.md` — extract generic schemas from `scripts.ddd` → `scripts/narrative` (filed: jjackson/canopy#160).
- **Plan 2-ACE** `…-ace-adopt-narrative-contract.md` — generate TS types from the canopy schema + wire video skills to invoke canopy validators / visual-judge.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)