### PR TITLE
feat(skills): /ace:video-render-local — local connect-videos render

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -195,6 +195,15 @@ ACE_CONNECT_APK_VERSION=2.63.0
 CONTENT_GENERATOR_URL=op://AI-Agents/Content Generator API/hostname
 CONTENT_GENERATOR_API_KEY=op://AI-Agents/Content Generator API/credential
 
+# ── Video rendering (connect-videos local renders) ──────────────────
+#
+# ElevenLabs API key for the connect-videos renderer's per-beat
+# voiceover. Read from process env by ace-web's `scripts/render_locally.py`
+# (and the `/ace:video-render-local` skill that wraps it) — the renderer
+# refuses to silently drop voice when a spec asks for elevenlabs. Same
+# 1Password item ace-web's own .env.tpl uses.
+ELEVENLABS_API_KEY=op://AI-Agents/ACE - ElevenLabs API Key/credential
+
 # ── ace-web Personal Access Token (per-human, per-machine) ─────────
 #
 # NOT 1Password-backed. Minted via /ace:ace-web-pat-mint (gh-style

--- a/commands/video-render-local.md
+++ b/commands/video-render-local.md
@@ -1,0 +1,25 @@
+---
+description: Render an ace-web connect-videos program to MP4 locally (bare-metal Mac, fast) — from a local spec + master clip, or an existing Drive program
+argument-hint: (--local-spec <spec.yaml> --master <clip.mp4> [--final]) | <program-slug> [<run-id>] [--publish]
+allowed-tools: [Read, Bash]
+---
+
+# /ace:video-render-local
+
+Render a connect-videos video program to `output.mp4` on the local host's
+Node/Chromium (1–3 min), instead of the slow server-side ace-web render.
+Two modes: a **local spec + master clip** (DDD `connect-ddd-walkthrough`,
+no Drive) or an **existing Drive program** by slug.
+
+**Read the skill and follow it** — it is the source of truth for checkout
+resolution, prerequisites, both modes, and how to read the timing report:
+
+```bash
+python3 -c "import json; d=json.load(open('$HOME/.claude/plugins/installed_plugins.json')); print(d['plugins']['ace@ace'][0]['installPath'] + '/skills/video-render-local/SKILL.md')"
+```
+
+Read that file with the Read tool and follow it. Map the invocation's
+arguments onto the skill's Mode A (`--local-spec` + `--master`) or Mode B
+(`<program-slug>`). Report the output mp4 path and the timing report to the
+user; flag any `held-frame overrun` so they can decide whether to trim the
+narration before shipping.

--- a/skills/video-render-local/SKILL.md
+++ b/skills/video-render-local/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: video-render-local
+description: >
+  Use when you need an ace-web connect-videos program rendered to MP4
+  locally and fast (bare-metal Mac), instead of the slow server-side
+  ace-web "Re-render" — including rendering a DDD connect-ddd-walkthrough
+  from a local spec + master clip with no Drive and no Django container.
+---
+
+# Video Render — Local (Mac-metal)
+
+Render an ace-web **connect-videos** program to `output.mp4` on the host's
+Node / Chromium / esbuild (1–3 min) instead of the slower Docker/server
+`/build` queue. Wraps ace-web's `scripts/render_locally.py`. ElevenLabs
+voiceover + music bed are muxed in; the renderer **holds the last frame of
+a clip range when its narration overruns**, so a too-long script shows up
+as frozen footage (see the timing report below).
+
+## When to use
+- Iterating on a video locally and you want the fast render, not the server queue.
+- Rendering a DDD narrative as a `connect-ddd-walkthrough` from a `spec.yaml` + master clip that exist only locally (e.g. canopy's emitter output) — **no Drive, no container**.
+- NOT for publishing to Drive/labs — that's the server `/build`, or Mode B with `--publish`.
+
+## Prerequisites
+- An **ace-web checkout** (default `~/emdash-projects/ace-web`; override `$ACE_WEB_ROOT`). It vendors the renderer at `video-production/connect-videos` and `scripts/render_locally.py`.
+- connect-videos deps installed once: `cd "$ACE_WEB/video-production/connect-videos" && npm ci` (~minutes). The script errors clearly if absent.
+- `ELEVENLABS_API_KEY` in the environment or the ace `.env` (1Password: `ACE - ElevenLabs API Key`). The renderer refuses to silently drop voice.
+- `ffmpeg` on PATH.
+
+## Resolve the checkout
+```bash
+ACE_WEB="${ACE_WEB_ROOT:-$HOME/emdash-projects/ace-web}"
+[ -f "$ACE_WEB/scripts/render_locally.py" ] || { echo "no ace-web checkout at $ACE_WEB — set ACE_WEB_ROOT"; exit 1; }
+```
+
+## Mode A — local spec + master clip (DDD / general, no Drive)
+The caller already has a connect-videos `spec.yaml` (e.g. canopy's emitted
+`explainer_spec.yaml`) and a master clip. Stage + render directly:
+```bash
+cd "$ACE_WEB"
+python scripts/render_locally.py \
+  --local-spec /path/to/spec.yaml \
+  --master     /path/to/walkthrough.mp4 \
+  --final            # omit for a faster --draft preview
+```
+Slug + run come from the spec (`slug:` / `--run`, default `run-001`); the
+master is copied to the spec's `manifest.master: file:…` path. Output:
+`video-production/connect-videos/programs/<slug>/runs/<run>/output.mp4`.
+
+## Mode B — existing Drive program (Docker app container up)
+```bash
+cd "$ACE_WEB"
+python scripts/render_locally.py <program-slug>            # or: <slug> <run-id>
+python scripts/render_locally.py --publish <program-slug>  # also push artifacts to Drive
+```
+
+## Read the output — the timing report
+After rendering the script prints:
+```
+clip footage (spec beats):   64.0s
+rendered duration:           77.5s
+held-frame overrun:         +13.5s  ⚠ VO overruns clips — trim narration
+```
+A large overrun means the narration is longer than the footage and the
+renderer froze the last frame waiting for the VO. Trim the narration to
+play continuously — budget **≈2.2 words/sec** for the ElevenLabs
+`eleven_turbo_v2` voice (not 2.5; that overshoots).
+
+## Pointing at a specific renderer
+`$CONNECT_VIDEOS_ROOT` (or `--connect-videos-root`) overrides just the
+connect-videos project — render against a canonical install regardless of
+which checkout the script lives in. Honored by both `render_locally.py`
+and its QA probe.
+
+## Common mistakes
+- **Stale checkout** — default is `~/emdash-projects/ace-web`; set `$ACE_WEB_ROOT` (or `$CONNECT_VIDEOS_ROOT`) to target another. Don't render from a feature worktree by accident.
+- **Missing `node_modules`** — `npm ci` in connect-videos once; the host arch must match (run on the Mac, not in the Linux container — that's the whole point).
+- **`--publish` in local-spec mode** — rejected; there's no Drive program. Use Mode B to publish.
+- **`manifest.master` not a `file:` ref** — local mode copies `--master` to the `file:` path the spec names; emit the spec with a `file:` master (canopy's DDD emitter does).
+
+## Intended caller
+canopy's on-demand `ddd-ace-render` emits the `connect-ddd-walkthrough`
+spec + records the master clip, then invokes this skill (Mode A) to produce
+the narrated MP4.


### PR DESCRIPTION
## Summary

Adds `/ace:video-render-local`, a general skill that renders an ace-web **connect-videos** program to MP4 **locally** (bare-metal Mac, 1–3 min) instead of the slow server-side ace-web render. It wraps ace-web's `scripts/render_locally.py`.

- **Mode A — local spec + master clip:** render a `connect-ddd-walkthrough` from a spec + recorded master that exist only locally (canopy's emitter output), with no Drive and no Django container.
- **Mode B — existing Drive program:** render by slug, optional `--publish`.
- Surfaces the renderer's **timing report** so VO-overrun (held last frame) is visible and the narration can be trimmed (~2.2 w/s for `eleven_turbo_v2`).

## Files

- `skills/video-render-local/SKILL.md` + `commands/video-render-local.md` — the skill + slash command.
- `.env.tpl` — `ELEVENLABS_API_KEY` (same 1Password item ace-web uses; the renderer refuses to silently drop voice).

## Dependency

Requires the ace-web side (PR jjackson/ace-web#655) for `render_locally.py`'s `--local-spec` mode. The skill is template-agnostic, so it's unaffected by the `connect-walkthrough → connect-ddd-walkthrough` rename. Intended caller: canopy's on-demand `ddd-ace-render`.

## Testing

The wrapped path was verified end-to-end (staged a local spec + master, rendered final quality, output.mp4 + timing report produced). `op read` of the new ref couldn't run in the authoring shell — verify via `/ace:doctor` (env_tpl_render) when signed into 1Password; the ref is identical to ace-web `main`'s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)