### PR TITLE
fix(demo): robust /ace:demo state-scaffold (dedicated script + absolute plugin path)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dimagi-internal"
   },
   "metadata": {
-    "version": "0.13.618"
+    "version": "0.13.619"
   },
   "plugins": [
     {
       "name": "ace",
       "source": "./",
-      "version": "0.13.618",
+      "version": "0.13.619",
       "description": "AI Connect Engine — orchestrates the ACE lifecycle from idea through app building, Connect setup, LLO management, and closeout"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ace",
-  "version": "0.13.618",
+  "version": "0.13.619",
   "description": "AI Connect Engine — orchestrates the ACE lifecycle from idea through app building, Connect setup, LLO management, and closeout",
   "author": {
     "name": "Jonathan Jackson",

--- a/agents/demo.md
+++ b/agents/demo.md
@@ -43,12 +43,15 @@ All three converge on the realized `${var}` map (`par_url`); everything from
    the Drive demo folder (`ACE/<name>/` + `runs/<runId>/7-synthetic/`) via the
    `ace-gdrive` atoms. Build the minimal structural `run_state.yaml` with the
    tested builder (DRY — do not hand-write the phase map):
+   Use the ABSOLUTE plugin path — `/ace:demo` runs from the user's session, so a
+   bare relative path to `lib/`/`scripts/` does NOT resolve (and `tsx -e` eval
+   can't resolve project imports at all):
    ```bash
-   npx tsx -e "import {buildDemoRunState} from './lib/demo-run-state.js'; \
-     import {stringify} from 'yaml'; \
-     process.stdout.write(stringify(buildDemoRunState({ \
-       demoName:'<name>', runId:'<runId>', source:'denovo', createdAt:new Date().toISOString()})))"
+   ACE_DIR="$HOME/.claude/plugins/cache/ace/ace/$(cat "$HOME/.claude/plugins/marketplaces/ace/VERSION")"
+   npx --prefix "$ACE_DIR" tsx "$ACE_DIR/scripts/emit-demo-run-state.ts" "<name>" "<runId>" "<denovo|clone|ace-run>"
    ```
+   (From the ace repo/worktree itself, `npx tsx scripts/emit-demo-run-state.ts
+   <name> <runId> <source>` also works.)
    Write the result to `ACE/<name>/runs/<runId>/run_state.yaml` (via
    `mcp__plugin_ace_ace-gdrive__drive_create_file`). Only
    `synthetic-data-and-workflows` is `in_progress`; all other pipeline phases are

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ace",
-  "version": "0.13.618",
+  "version": "0.13.619",
   "description": "AI Connect Engine - orchestrator for building Connect Opps using AI",
   "type": "module",
   "scripts": {

--- a/scripts/emit-demo-run-state.ts
+++ b/scripts/emit-demo-run-state.ts
@@ -1,0 +1,6 @@
+// Emit a demo run_state.yaml to stdout. Usage: npx tsx scripts/emit-demo-run-state.ts <demoName> <runId> <denovo|clone|ace-run>
+import { buildDemoRunState } from '../lib/demo-run-state.js';
+import { stringify } from 'yaml';
+const [demoName, runId, source] = process.argv.slice(2);
+if (!demoName || !runId || !source) { console.error('usage: emit-demo-run-state <demoName> <runId> <denovo|clone|ace-run>'); process.exit(2); }
+process.stdout.write(stringify(buildDemoRunState({ demoName, runId, source: source as any, createdAt: new Date().toISOString() })));


### PR DESCRIPTION
The step-2 state-scaffold in `agents/demo.md` would have **blocked the first executable step of a real `/ace:demo`**: the `npx tsx -e` one-liner can't resolve project imports (`Cannot find module ./lib/demo-run-state.js`), and a bare relative path wouldn't resolve anyway since `/ace:demo` runs from the user's session, not the plugin dir.

Fix: `scripts/emit-demo-run-state.ts` (dedicated CLI over the tested `buildDemoRunState`) invoked via the absolute plugin-cache path (the established ACE pattern, same as the auth block). Verified working from a foreign cwd. Caught while finalizing before the live end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)