### PR TITLE
fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,21 +6,13 @@
     "url": "https://github.com/dimagi-internal"
   },
   "metadata": {
-<<<<<<< HEAD
-    "version": "0.13.1355"
-=======
     "version": "0.13.1356"
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   },
   "plugins": [
     {
       "name": "ace",
       "source": "./",
-<<<<<<< HEAD
-      "version": "0.13.1355",
-=======
       "version": "0.13.1356",
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
       "description": "AI Connect Engine — orchestrates the ACE lifecycle from idea through app building, Connect setup, LLO management, and closeout"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,21 @@
     "url": "https://github.com/dimagi-internal"
   },
   "metadata": {
+<<<<<<< HEAD
     "version": "0.13.1355"
+=======
+    "version": "0.13.1356"
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   },
   "plugins": [
     {
       "name": "ace",
       "source": "./",
+<<<<<<< HEAD
       "version": "0.13.1355",
+=======
+      "version": "0.13.1356",
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
       "description": "AI Connect Engine — orchestrates the ACE lifecycle from idea through app building, Connect setup, LLO management, and closeout"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,10 @@
 {
   "name": "ace",
+<<<<<<< HEAD
   "version": "0.13.1355",
+=======
+  "version": "0.13.1356",
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   "description": "AI Connect Engine — orchestrates the ACE lifecycle from idea through app building, Connect setup, LLO management, and closeout",
   "author": {
     "name": "Jonathan Jackson",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,6 @@
 {
   "name": "ace",
-<<<<<<< HEAD
-  "version": "0.13.1355",
-=======
   "version": "0.13.1356",
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   "description": "AI Connect Engine — orchestrates the ACE lifecycle from idea through app building, Connect setup, LLO management, and closeout",
   "author": {
     "name": "Jonathan Jackson",

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-0.13.1355
-=======
 0.13.1356
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 0.13.1355
+=======
+0.13.1356
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)

--- a/lib/run-surface-audit.ts
+++ b/lib/run-surface-audit.ts
@@ -2318,12 +2318,32 @@ export function auditReviewerMembership(
         continue;
       }
       if (!known[reviewer]) {
+        // An ADMIN-tagged link is a different promise from a reviewer-facing
+        // one. The page labels it `admin`, so a reviewer who cannot open it
+        // has been told as much up front — that is the tag doing its job, not
+        // a wall they were walked into (Jon, 2026-09-08). Blocking the share
+        // on it would mean either granting console access nobody needs, or
+        // stripping links that legitimately document what the run built.
+        //
+        // What this does NOT relax is the case #1060 was filed for: a link
+        // presented as reviewer-facing (`public` / `member`) that 404s for the
+        // named reviewer stays `broken`, because there the page's own label is
+        // what turns out to be untrue.
+        const isAdminLink = l.declaredAccess === 'admin';
         out.push({
-          code: 'MEMBER-MISSING',
-          severity: 'broken',
+          code: isAdminLink ? 'ADMIN-LINK-NOT-MEMBER' : 'MEMBER-MISSING',
+          severity: isAdminLink ? 'improvement' : 'broken',
           where: `${l.label} → ${reviewer}`,
-          detail: `${reviewer} is NOT a member on ${surface} and will get a flat 404 on ${l.url}`,
-          fix: 'grant access first (skills/share-run-access), or do not present this link to them as reviewer-facing',
+          detail: isAdminLink
+            ? `${reviewer} is NOT a member on ${surface}, so ${l.url} will 404 for them. ` +
+              `The page tags it \`admin\`, so this is expected and does not block sharing — ` +
+              `recorded so nobody reports it back as a broken link`
+            : `${reviewer} is NOT a member on ${surface} and will get a flat 404 on ${l.url}`,
+          fix: isAdminLink
+            ? 'nothing required. Grant access via skills/share-run-access only if this reviewer ' +
+              'genuinely needs the admin surface — for the per-opp chatbot the anonymous chat URL ' +
+              'is the reviewer-facing route and is already on the page'
+            : 'grant access first (skills/share-run-access), or do not present this link to them as reviewer-facing',
         });
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,12 @@
 {
   "name": "ace",
-<<<<<<< HEAD
-  "version": "0.13.1355",
-=======
   "version": "0.13.1356",
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ace",
-<<<<<<< HEAD
-      "version": "0.13.1355",
-=======
       "version": "0.13.1356",
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.94.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
   "name": "ace",
+<<<<<<< HEAD
   "version": "0.13.1355",
+=======
+  "version": "0.13.1356",
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ace",
+<<<<<<< HEAD
       "version": "0.13.1355",
+=======
+      "version": "0.13.1356",
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.94.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "ace",
-<<<<<<< HEAD
-  "version": "0.13.1355",
-=======
   "version": "0.13.1356",
->>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   "engines": {
     "node": ">=22"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "ace",
+<<<<<<< HEAD
   "version": "0.13.1355",
+=======
+  "version": "0.13.1356",
+>>>>>>> 6c8d3813 (fix(run-surface-audit): an admin-tagged link a reviewer cannot open is not a broken link)
   "engines": {
     "node": ">=22"
   },

--- a/test/lib/run-surface-audit.test.ts
+++ b/test/lib/run-surface-audit.test.ts
@@ -346,6 +346,44 @@ describe('defect 4 — a link an outsider cannot open must say so', () => {
     expect(ok).toEqual([]);
   });
 
+  it('does NOT block the share when the unopenable link is tagged `admin`', () => {
+    // Jon, 2026-09-08: an admin-tagged link a reviewer cannot open is the tag
+    // doing its job, not a wall they were walked into. Blocking on it would
+    // mean granting console access nobody needs, or stripping links that
+    // legitimately document what the run built. Live case: the per-opp OCS
+    // console on poverty-graduation/20260905-1345, where the reviewer-facing
+    // route (the anonymous chat URL) was already on the same page and worked.
+    const adminLink = probed({
+      url: 'https://www.openchatstudio.com/a/connect-ace/chatbots/13068/',
+      cls: 'MEMBER-GATED',
+      declaredAccess: 'admin',
+    });
+    const found = auditReviewerMembership([adminLink], ['sophie@example.org'], {
+      ocs: { 'sophie@example.org': false },
+    });
+    expect(codes(found)).toEqual(['ADMIN-LINK-NOT-MEMBER']);
+    // Still SURFACED — so nobody reports it back to us as a broken link —
+    // but it must not gate the share.
+    expect(found.every(isBlocking)).toBe(false);
+  });
+
+  it('still blocks when a link the page presents as REVIEWER-FACING 404s for that reviewer', () => {
+    // The #1060 case is untouched by the admin carve-out above: here the
+    // page's own label is what turns out to be untrue.
+    for (const declaredAccess of ['public', 'member', null]) {
+      const link = probed({
+        url: 'https://www.commcarehq.org/a/dom/apps/view/x/',
+        cls: 'MEMBER-GATED',
+        declaredAccess,
+      });
+      const found = auditReviewerMembership([link], ['sophie@example.org'], {
+        hq: { 'sophie@example.org': false },
+      });
+      expect(codes(found), `declaredAccess=${declaredAccess}`).toEqual(['MEMBER-MISSING']);
+      expect(found.every(isBlocking), `declaredAccess=${declaredAccess}`).toBe(true);
+    }
+  });
+
   it('does not mistake a labs dashboard for a membership-gated Connect page', () => {
     // `labs.connect.dimagi.com` CONTAINS `connect.dimagi.com`; its /labs/ pages
     // are merely login-gated. The path prefix is load-bearing.


### PR DESCRIPTION
`MEMBER-MISSING` was `broken` for every member-gated link a named reviewer could not open, **regardless of how the page labelled it**. That blocked the `poverty-graduation/20260905-1345` share on the per-opp OCS **admin console** — a surface that reviewer has no use for, and whose reviewer-facing counterpart (the anonymous chat URL) was already on the same page and working.

The two cases are different promises. A link tagged `admin` has told the reader up front that it is not for them; a reviewer who cannot open it met the tag doing its job, not a wall they were walked into. Blocking on it leaves two bad options: grant console access nobody needs, or strip links that legitimately document what the run built.

## The change

An `admin`-tagged link with a **confirmed** non-member now reports `ADMIN-LINK-NOT-MEMBER` at `improvement`. Still surfaced — the point of recording it is that nobody comes back to us calling it broken — but it no longer gates the share.

## What this does NOT relax

The case #1060 was filed for. A link the page presents as **reviewer-facing** (`public`, `member`, or untagged) that 404s for the named reviewer stays `broken`, because there the page's own label is what turns out to be untrue. That leg is pinned by its own test across all three tag values, so the carve-out cannot widen by accident.

`MEMBER-UNVERIFIED` is untouched: "we did not check" stays blocking for every link class.

## Effect on the live run

```
before:  1 broken, 1 misleading
after:   0 broken, 1 misleading, 1 improvement
```

The remaining `misleading` is `DOC-FIDELITY-UNVERIFIED` on the PDD, unresolvable for this run by construction — its `.source.md` predates the ace#2102 fix.

`tsc --noEmit` clean; full suite **8,086 passing**.

Jon's call, 2026-09-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)